### PR TITLE
Doc improvement and force reconnection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Installing Telethon manually
    (`GitHub <https://github.com/ricmoo/pyaes>`_, `package index <https://pypi.python.org/pypi/pyaes>`_)
 2. Clone Telethon's GitHub repository: ``git clone https://github.com/LonamiWebs/Telethon.git``
 3. Enter the cloned repository: ``cd Telethon``
-4. Run the code generator: ``python3 telethon_generator/tl_generator.py``
+4. Run the code generator: ``cd telethon_generator && python3 tl_generator.py``
 5. Done!
 
 Running Telethon

--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -90,7 +90,7 @@ class TelegramClient:
            Note that authenticating to the Telegram servers is not the same as authenticating
            the app, which requires to send a code first."""
         try:
-            if not self.session.auth_key or reconnect:
+            if not self.session.auth_key or (reconnect and self.sender is not None):
                 self.session.auth_key, self.session.time_offset = \
                     authenticator.do_authentication(self.transport)
 
@@ -146,6 +146,7 @@ class TelegramClient:
         """Disconnects from the Telegram server **and pauses all the spawned threads**"""
         if self.sender:
             self.sender.disconnect()
+            self.sender = None
 
     # endregion
 

--- a/telethon_generator/tl_generator.py
+++ b/telethon_generator/tl_generator.py
@@ -2,7 +2,10 @@ import os
 import re
 import shutil
 
-from .parser import SourceBuilder, TLParser
+try:
+    from .parser import SourceBuilder, TLParser
+except (ImportError, SystemError):
+    from parser import SourceBuilder, TLParser
 
 
 def get_output_path(normal_path):


### PR DESCRIPTION
1. Relative imports does not allowed if module was not loaded. This fails manual install
2. `reconnect` flag fails saved session if client was not previously connected