### PR TITLE
Raise an exception if recv() returned 0 bytes

### DIFF
--- a/telethon/network/tcp_client.py
+++ b/telethon/network/tcp_client.py
@@ -82,6 +82,9 @@ class TcpClient:
                         # This is why we need to keep checking to make sure that we receive it all
                         left_count = buffer_size - writer.written_count
                         partial = self.socket.recv(left_count)
+                        if len(partial) == 0:
+                            raise ConnectionResetError(
+                                'The server has closed the connection (recv() returned 0 bytes).')
                         writer.write(partial)
 
                     except BlockingIOError as error:


### PR DESCRIPTION
See for details: https://docs.python.org/3/howto/sockets.html
"When a recv returns 0 bytes, it means the other side has closed (or is in the process of closing) the connection. You will not receive any more data on this connection. Ever."