### PR TITLE
(Add) Add to_dict() method

### DIFF
--- a/telethon_generator/tl_generator.py
+++ b/telethon_generator/tl_generator.py
@@ -212,6 +212,31 @@ class TLGenerator:
                         for arg in args:
                             builder.writeln('self.{0} = {0}'.format(arg.name))
                     builder.end_block()
+                    
+                    # Write the to_dict(self) method
+                    builder.writeln('def to_dict(self):')
+                    if args:
+                        builder.writeln('return {')
+                        
+                        base_types = ["string", "bytes", "int", "long", "int128", "int256", "double", "Bool", "true",
+                                      "date"]
+                        
+                        for arg in args:
+                            if arg.is_vector:
+                                builder.writeln("\'{}\': [_{} for _ in self.{}] if self.{} is not None else [],"
+                                                .format(arg.name, ".to_dict() if _ is not None else None"
+                                                                  if arg.type not in base_types else "",
+                                                        arg.name, arg.name))
+                            else:
+                                builder.writeln("\'{}\': self.{}{}, "
+                                                .format(arg.name, arg.name,
+                                                        ".to_dict() if self.{} is not None else None".format(arg.name)
+                                                        if arg.type not in base_types else ""))
+                        builder.write("}")
+                    else:
+                        builder.writeln('return {}')
+                    builder.writeln()
+                    builder.end_block()
 
                     # Write the on_send(self, writer) function
                     builder.writeln('def on_send(self, writer):')

--- a/telethon_generator/tl_generator.py
+++ b/telethon_generator/tl_generator.py
@@ -222,14 +222,15 @@ class TLGenerator:
                                       "date"]
                         
                         for arg in args:
+                            builder.writeln("\'{}\': ".format(arg.name))
                             if arg.is_vector:
-                                builder.writeln("\'{}\': [_{} for _ in self.{}] if self.{} is not None else [],"
-                                                .format(arg.name, ".to_dict() if _ is not None else None"
+                                builder.writeln("[x{} for x in self.{}] if self.{} is not None else [],"
+                                                .format(".to_dict() if x is not None else None"
                                                                   if arg.type not in base_types else "",
                                                         arg.name, arg.name))
                             else:
-                                builder.writeln("\'{}\': self.{}{}, "
-                                                .format(arg.name, arg.name,
+                                builder.writeln("self.{}{},"
+                                                .format(arg.name,
                                                         ".to_dict() if self.{} is not None else None".format(arg.name)
                                                         if arg.type not in base_types else ""))
                         builder.write("}")


### PR DESCRIPTION
This commit adds to_dict() method, and you can build dict object from each tl object.

Method samples:
```
def to_dict(self):
        return {
        'pinned': self.pinned, 
        'peer': self.peer.to_dict() if self.peer is not None else None, 
        'top_message': self.top_message, 
        'read_inbox_max_id': self.read_inbox_max_id, 
        'read_outbox_max_id': self.read_outbox_max_id, 
        'unread_count': self.unread_count, 
        'notify_settings': self.notify_settings.to_dict() if self.notify_settings is not None else None, 
        'pts': self.pts, 
        'draft': self.draft.to_dict() if self.draft is not None else None, 
        }
```

```
def to_dict(self):
        return {
        'messages': [_.to_dict() if _ is not None else None for _ in self.messages] if self.messages is not None else [],
        'chats': [_.to_dict() if _ is not None else None for _ in self.chats] if self.chats is not None else [],
        'users': [_.to_dict() if _ is not None else None for _ in self.users] if self.users is not None else [],
        }

```
