### PR TITLE
(Fix) Fix api_id type mismatch

### DIFF
--- a/telethon/telegram_bare_client.py
+++ b/telethon/telegram_bare_client.py
@@ -58,7 +58,7 @@ class TelegramBareClient:
         """
 
         self.session = session
-        self.api_id = api_id
+        self.api_id = int(api_id)
         self.api_hash = api_hash
         self.proxy = proxy
         self._logger = logging.getLogger(__name__)


### PR DESCRIPTION
This commit fixes pretty obvious error, by passing str insted int for api_id parameter

```
client = telethon.TelegramClient('phone_number', "api_id", "api_hash")
```

Here is error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Program Files\Python35\lib\site-packages\telethon\telegram_client.py", line 177, in connect
    layer=layer, query=query))
  File "C:\Program Files\Python35\lib\site-packages\telethon\telegram_client.py", line 326, in invoke
    self.sender.send(request)
  File "C:\Program Files\Python35\lib\site-packages\telethon\network\mtproto_sender.py", line 63, in send
    request.on_send(writer)
  File "C:\Program Files\Python35\lib\site-packages\telethon\tl\functions\invoke_with_layer.py", line 34, in on_send
    self.query.on_send(writer)
  File "C:\Program Files\Python35\lib\site-packages\telethon\tl\functions\init_connection.py", line 45, in on_send
    writer.write_int(self.api_id)
  File "C:\Program Files\Python35\lib\site-packages\telethon\utils\binary_writer.py", line 31, in write_int
    value, length=4, byteorder='little', signed=signed))
TypeError: descriptor 'to_bytes' requires a 'int' object but received a 'str'
```