### PR TITLE
fix broken link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Using Telethon
 ==============
 If you really want to learn how to use Telethon, it is **highly advised** that
 you take a look to the
-`InteractiveTelegramClient <telethon_examples/interactive_telegram_client.py>`_
+`InteractiveTelegramClient <https://github.com/LonamiWebs/Telethon/blob/master/telethon_examples/interactive_telegram_client.py>`_
 file and check how it works. This file contains everything you'll need to
 build your own application, since it shows, among other things:
 


### PR DESCRIPTION
Use absolute url to support reading the READMI.rst on PyPI