### PR TITLE
Catching WinError 10038

### DIFF
--- a/telethon/extensions/tcp_client.py
+++ b/telethon/extensions/tcp_client.py
@@ -100,7 +100,7 @@ class TcpClient:
                 except socket.timeout as e:
                     raise TimeoutError() from e
                 except OSError as e:
-                    if e.errno == errno.EBADF:
+                    if e.errno == errno.EBADF or e.errno == errno.ENOTSOCK:
                         self._raise_connection_reset()
                     else:
                         raise


### PR DESCRIPTION
While client.connect() there was `OSError: [WinError 10038] an operation was attempted on something that is not a socket`