### PR TITLE
Several parallel connections and update workers

### DIFF
--- a/telethon/network/connection.py
+++ b/telethon/network/connection.py
@@ -130,6 +130,13 @@ class Connection:
     def close(self):
         self.conn.close()
 
+    def clone(self):
+        """Creates a copy of this Connection"""
+        return Connection(self.ip, self.port,
+                          mode=self._mode,
+                          proxy=self.conn.proxy,
+                          timeout=self.conn.timeout)
+
     # region Receive message implementations
 
     def recv(self):

--- a/telethon/network/mtproto_sender.py
+++ b/telethon/network/mtproto_sender.py
@@ -1,7 +1,6 @@
 import gzip
 import logging
 import struct
-from threading import RLock
 
 from .. import helpers as utils
 from ..crypto import AES
@@ -20,7 +19,12 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class MtProtoSender:
     """MTProto Mobile Protocol sender
-       (https://core.telegram.org/mtproto/description)
+       (https://core.telegram.org/mtproto/description).
+
+       Note that this class is not thread-safe, and calling send/receive
+       from two or more threads at the same time is undefined behaviour.
+       Rationale: a new connection should be spawned to send/receive requests
+                  in parallel, so thread-safety (hence locking) isn't needed.
     """
 
     def __init__(self, session, connection):
@@ -36,11 +40,6 @@ class MtProtoSender:
 
         # Requests (as msg_id: Message) sent waiting to be received
         self._pending_receive = {}
-
-        # Sending and receiving are independent, but two threads cannot
-        # send or receive at the same time no matter what.
-        self._send_lock = RLock()
-        self._recv_lock = RLock()
 
     def connect(self):
         """Connects to the server"""
@@ -93,19 +92,18 @@ class MtProtoSender:
            Any unhandled object (likely updates) will be passed to
            update_state.process(TLObject).
         """
-        with self._recv_lock:
-            try:
-                body = self.connection.recv()
-            except (BufferError, InvalidChecksumError):
-                # TODO BufferError, we should spot the cause...
-                # "No more bytes left"; something wrong happened, clear
-                # everything to be on the safe side, or:
-                #
-                # "This packet should be skipped"; since this may have
-                # been a result for a request, invalidate every request
-                # and just re-invoke them to avoid problems
-                self._clear_all_pending()
-                return
+        try:
+            body = self.connection.recv()
+        except (BufferError, InvalidChecksumError):
+            # TODO BufferError, we should spot the cause...
+            # "No more bytes left"; something wrong happened, clear
+            # everything to be on the safe side, or:
+            #
+            # "This packet should be skipped"; since this may have
+            # been a result for a request, invalidate every request
+            # and just re-invoke them to avoid problems
+            self._clear_all_pending()
+            return
 
         message, remote_msg_id, remote_seq = self._decode_msg(body)
         with BinaryReader(message) as reader:
@@ -128,8 +126,7 @@ class MtProtoSender:
         cipher_text = AES.encrypt_ige(plain_text, key, iv)
 
         result = key_id + msg_key + cipher_text
-        with self._send_lock:
-            self.connection.send(result)
+        self.connection.send(result)
 
     def _decode_msg(self, body):
         """Decodes an received encrypted message body bytes"""

--- a/telethon/network/mtproto_sender.py
+++ b/telethon/network/mtproto_sender.py
@@ -54,6 +54,10 @@ class MtProtoSender:
         self._need_confirmation.clear()
         self._clear_all_pending()
 
+    def clone(self):
+        """Creates a copy of this MtProtoSender as a new connection"""
+        return MtProtoSender(self.session, self.connection.clone())
+
     # region Send and receive
 
     def send(self, *requests):

--- a/telethon/telegram_bare_client.py
+++ b/telethon/telegram_bare_client.py
@@ -410,8 +410,7 @@ class TelegramBareClient:
                 if result:
                     return result
 
-            if retries <= 0:
-                raise ValueError('Number of retries reached 0.')
+            raise ValueError('Number of retries reached 0.')
         finally:
             if sender != self._sender:
                 sender.disconnect()  # Close temporary connections

--- a/telethon/telegram_bare_client.py
+++ b/telethon/telegram_bare_client.py
@@ -68,6 +68,7 @@ class TelegramBareClient:
                  connection_mode=ConnectionMode.TCP_FULL,
                  proxy=None,
                  update_workers=None,
+                 spawn_read_thread=True,
                  timeout=timedelta(seconds=5),
                  **kwargs):
         """Refer to TelegramClient.__init__ for docs on this method"""
@@ -131,7 +132,9 @@ class TelegramBareClient:
         # Uploaded files cache so subsequent calls are instant
         self._upload_cache = {}
 
-        # Constantly read for results and updates from within the main client
+        # Constantly read for results and updates from within the main client,
+        # if the user has left enabled such option.
+        self._spawn_read_thread = spawn_read_thread
         self._recv_thread = None
 
         # Identifier of the main thread (the one that called .connect()).
@@ -704,7 +707,7 @@ class TelegramBareClient:
 
     def _set_connected_and_authorized(self):
         self._authorized = True
-        if self._recv_thread is None:
+        if self._spawn_read_thread and self._recv_thread is None:
             self._recv_thread = threading.Thread(
                 name='ReadThread', daemon=True,
                 target=self._recv_thread_impl

--- a/telethon/telegram_bare_client.py
+++ b/telethon/telegram_bare_client.py
@@ -201,13 +201,16 @@ class TelegramBareClient:
                     self(GetConfigRequest()).dc_options
 
             # Connection was successful! Try syncing the update state
+            # IF we don't have an exported authorization (hence we're
+            # not in our NATIVE data center or we'd get UserMigrateError)
             # to also assert whether the user is logged in or not.
             self._user_connected = True
-            try:
-                self.sync_updates()
-                self._set_connected_and_authorized()
-            except UnauthorizedError:
-                self._authorized = False
+            if not exported_auth:
+                try:
+                    self.sync_updates()
+                    self._set_connected_and_authorized()
+                except UnauthorizedError:
+                    self._authorized = False
 
             return True
 

--- a/telethon/telegram_bare_client.py
+++ b/telethon/telegram_bare_client.py
@@ -67,7 +67,7 @@ class TelegramBareClient:
     def __init__(self, session, api_id, api_hash,
                  connection_mode=ConnectionMode.TCP_FULL,
                  proxy=None,
-                 process_updates=False,
+                 update_workers=None,
                  timeout=timedelta(seconds=5),
                  **kwargs):
         """Refer to TelegramClient.__init__ for docs on this method"""
@@ -108,7 +108,7 @@ class TelegramBareClient:
 
         # This member will process updates if enabled.
         # One may change self.updates.enabled at any later point.
-        self.updates = UpdateState(process_updates)
+        self.updates = UpdateState(workers=update_workers)
 
         # Used on connection - the user may modify these and reconnect
         kwargs['app_version'] = kwargs.get('app_version', self.__version__)

--- a/telethon/telegram_bare_client.py
+++ b/telethon/telegram_bare_client.py
@@ -68,7 +68,7 @@ class TelegramBareClient:
                  connection_mode=ConnectionMode.TCP_FULL,
                  proxy=None,
                  update_workers=None,
-                 spawn_read_thread=True,
+                 spawn_read_thread=False,
                  timeout=timedelta(seconds=5),
                  **kwargs):
         """Refer to TelegramClient.__init__ for docs on this method"""

--- a/telethon/telegram_bare_client.py
+++ b/telethon/telegram_bare_client.py
@@ -388,18 +388,11 @@ class TelegramBareClient:
             raise ValueError('You can only invoke requests, not types!')
 
         # Determine the sender to be used (main or a new connection)
-        # TODO Polish this so it's nicer
         on_main_thread = threading.get_ident() == self._main_thread_ident
         if on_main_thread or self._on_read_thread():
             sender = self._sender
         else:
-            conn = Connection(
-                self.session.server_address, self.session.port,
-                mode=self._sender.connection._mode,
-                proxy=self._sender.connection.conn.proxy,
-                timeout=self._sender.connection.get_timeout()
-            )
-            sender = MtProtoSender(self.session, conn)
+            sender = self._sender.clone()
             sender.connect()
 
         # We should call receive from this thread if there's no background

--- a/telethon/telegram_bare_client.py
+++ b/telethon/telegram_bare_client.py
@@ -154,7 +154,7 @@ class TelegramBareClient:
 
     # region Connecting
 
-    def connect(self, _exported_auth=None, _sync_updates=True, cdn=False):
+    def connect(self, _exported_auth=None, _sync_updates=True, _cdn=False):
         """Connects to the Telegram servers, executing authentication if
            required. Note that authenticating to the Telegram servers is
            not the same as authenticating the desired user itself, which
@@ -171,7 +171,7 @@ class TelegramBareClient:
            native data center, raising a "UserMigrateError", and
            calling .disconnect() in the process.
 
-           If 'cdn' is False, methods that are not allowed on such data
+           If '_cdn' is False, methods that are not allowed on such data
            centers won't be invoked.
         """
         self._main_thread_ident = threading.get_ident()
@@ -198,7 +198,7 @@ class TelegramBareClient:
                     self._init_connection(ImportAuthorizationRequest(
                         _exported_auth.id, _exported_auth.bytes
                     ))
-                elif not cdn:
+                elif not _cdn:
                     TelegramBareClient._dc_options = \
                         self._init_connection(GetConfigRequest()).dc_options
 
@@ -207,7 +207,7 @@ class TelegramBareClient:
                     _exported_auth.id, _exported_auth.bytes
                 ))
 
-            if TelegramBareClient._dc_options is None and not cdn:
+            if TelegramBareClient._dc_options is None and not _cdn:
                 TelegramBareClient._dc_options = \
                     self(GetConfigRequest()).dc_options
 
@@ -216,7 +216,7 @@ class TelegramBareClient:
             # another data center and this would raise UserMigrateError)
             # to also assert whether the user is logged in or not.
             self._user_connected = True
-            if _sync_updates and not cdn:
+            if _sync_updates and not _cdn:
                 try:
                     self.sync_updates()
                     self._set_connected_and_authorized()
@@ -231,7 +231,8 @@ class TelegramBareClient:
             self.disconnect()
             return self.connect(
                 _exported_auth=_exported_auth,
-                _sync_updates=_sync_updates
+                _sync_updates=_sync_updates,
+                _cdn=_cdn
             )
 
         except (RPCError, ConnectionError) as error:

--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -59,6 +59,7 @@ class TelegramClient(TelegramBareClient):
                  proxy=None,
                  update_workers=None,
                  timeout=timedelta(seconds=5),
+                 spawn_read_thread=True,
                  **kwargs):
         """Initializes the Telegram client with the specified API ID and Hash.
 
@@ -77,9 +78,15 @@ class TelegramClient(TelegramBareClient):
              > 0: 'update_workers' background threads will be spawned, any
                   any of them will invoke all the self.updates.handlers.
 
-           Despite the value of 'process_updates', if you later call
-           '.add_update_handler(...)', updates will also be processed
-           and the update objects will be passed to the handlers you added.
+           If 'spawn_read_thread', a background thread will be started once
+           an authorized user has been logged in to Telegram to read items
+           (such as updates and responses) from the network as soon as they
+           occur, which will speed things up.
+
+           If you don't want to spawn any additional threads, pending updates
+           will be read and processed accordingly after invoking a request
+           and not immediately. This is useful if you don't care about updates
+           at all and have set 'update_workers=None'.
 
            If more named arguments are provided as **kwargs, they will be
            used to update the Session instance. Most common settings are:
@@ -95,6 +102,7 @@ class TelegramClient(TelegramBareClient):
             connection_mode=connection_mode,
             proxy=proxy,
             update_workers=update_workers,
+            spawn_read_thread=spawn_read_thread,
             timeout=timeout
         )
 

--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -1,10 +1,7 @@
 import os
-import threading
 from datetime import datetime, timedelta
 from functools import lru_cache
 from mimetypes import guess_type
-from threading import Thread
-from time import sleep
 
 try:
     import socks
@@ -15,12 +12,10 @@ from . import TelegramBareClient
 from . import helpers as utils
 from .errors import (
     RPCError, UnauthorizedError, InvalidParameterError, PhoneCodeEmptyError,
-    PhoneMigrateError, NetworkMigrateError, UserMigrateError,
     PhoneCodeExpiredError, PhoneCodeHashEmptyError, PhoneCodeInvalidError
 )
-from .network import Connection, ConnectionMode, MtProtoSender
-from .tl import Session, TLObject
-from .tl.functions import PingRequest
+from .network import ConnectionMode
+from .tl import TLObject
 from .tl.functions.account import (
     GetPasswordRequest
 )
@@ -34,9 +29,6 @@ from .tl.functions.contacts import (
 from .tl.functions.messages import (
     GetDialogsRequest, GetHistoryRequest, ReadHistoryRequest, SendMediaRequest,
     SendMessageRequest
-)
-from .tl.functions.updates import (
-    GetStateRequest
 )
 from .tl.functions.users import (
     GetUsersRequest
@@ -98,18 +90,6 @@ class TelegramClient(TelegramBareClient):
              system_lang_code = lang_code
              report_errors    = True
         """
-        if not api_id or not api_hash:
-            raise PermissionError(
-                "Your API ID or Hash cannot be empty or None. "
-                "Refer to Telethon's README.rst for more information.")
-
-        # Determine what session object we have
-        if isinstance(session, str) or session is None:
-            session = Session.try_load_or_create_new(session)
-        elif not isinstance(session, Session):
-            raise ValueError(
-                'The given session must be a str or a Session instance.')
-
         super().__init__(
             session, api_id, api_hash,
             connection_mode=connection_mode,
@@ -118,186 +98,15 @@ class TelegramClient(TelegramBareClient):
             timeout=timeout
         )
 
-        # Used on connection - the user may modify these and reconnect
-        kwargs['app_version'] = kwargs.get('app_version', self.__version__)
-        for name, value in kwargs.items():
-            if hasattr(self.session, name):
-                setattr(self.session, name, value)
-
-        self._updates_thread = None
+        # Some fields to easy signing in
         self._phone_code_hash = None
         self._phone = None
-
-        # Despite the state of the real connection, keep track of whether
-        # the user has explicitly called .connect() or .disconnect() here.
-        # This information is required by the read thread, who will be the
-        # one attempting to reconnect on the background *while* the user
-        # doesn't explicitly call .disconnect(), thus telling it to stop
-        # retrying. The main thread, knowing there is a background thread
-        # attempting reconnection as soon as it happens, will just sleep.
-        self._user_connected = False
-
-        # Save whether the user is authorized here (a.k.a. logged in)
-        self._authorized = False
-
-        # Uploaded files cache so subsequent calls are instant
-        self._upload_cache = {}
-
-        # Constantly read for results and updates from within the main client
-        self._recv_thread = None
-
-        # Identifier of the main thread (the one that called .connect()).
-        # This will be used to create new connections from any other thread,
-        # so that requests can be sent in parallel.
-        self._main_thread_ident = None
-
-        # Default PingRequest delay
-        self._last_ping = datetime.now()
-        self._ping_delay = timedelta(minutes=1)
-
-    # endregion
-
-    # region Connecting
-
-    def connect(self, exported_auth=None):
-        """Connects to the Telegram servers, executing authentication if
-           required. Note that authenticating to the Telegram servers is
-           not the same as authenticating the desired user itself, which
-           may require a call (or several) to 'sign_in' for the first time.
-
-           exported_auth is meant for internal purposes and can be ignored.
-        """
-        self._main_thread_ident = threading.get_ident()
-
-        if socks and self._recv_thread:
-            # Treat proxy errors specially since they're not related to
-            # Telegram itself, but rather to the proxy. If any happens on
-            # the read thread forward it to the main thread.
-            try:
-                ok = super().connect(exported_auth=exported_auth)
-            except socks.ProxyConnectionError as e:
-                ok = False
-                # Report the exception to the main thread
-                self.updates.set_error(e)
-        else:
-            ok = super().connect(exported_auth=exported_auth)
-
-        if not ok:
-            return False
-
-        self._user_connected = True
-        try:
-            self.sync_updates()
-            self._set_connected_and_authorized()
-        except UnauthorizedError:
-            self._authorized = False
-
-        return True
-
-    def disconnect(self):
-        """Disconnects from the Telegram server
-           and stops all the spawned threads"""
-        self._user_connected = False
-        self._recv_thread = None
-
-        # This will trigger a "ConnectionResetError", usually, the background
-        # thread would try restarting the connection but since the
-        # ._recv_thread = None, it knows it doesn't have to.
-        super().disconnect()
-
-        # Also disconnect all the cached senders
-        for sender in self._cached_clients.values():
-            sender.disconnect()
-
-        self._cached_clients.clear()
-
-    # endregion
-
-    # region Working with different connections
-
-    def _on_read_thread(self):
-        return self._recv_thread is not None and \
-               threading.get_ident() == self._recv_thread.ident
 
     # endregion
 
     # region Telegram requests functions
 
-    def invoke(self, *requests, **kwargs):
-        """Invokes (sends) one or several MTProtoRequest and returns
-           (receives) their result. An optional named 'retries' parameter
-           can be used, indicating how many times it should retry.
-        """
-        # This is only valid when the read thread is reconnecting,
-        # that is, the connection lock is locked.
-        on_read_thread = self._on_read_thread()
-        if on_read_thread and not self._connect_lock.locked():
-            return  # Just ignore, we would be raising and crashing the thread
-
-        self.updates.check_error()
-
-        # Determine the sender to be used (main or a new connection)
-        # TODO Polish this so it's nicer
-        on_main_thread = threading.get_ident() == self._main_thread_ident
-        if on_main_thread or on_read_thread:
-            sender = self._sender
-        else:
-            conn = Connection(
-                self.session.server_address, self.session.port,
-                mode=self._sender.connection._mode,
-                proxy=self._sender.connection.conn.proxy,
-                timeout=self._sender.connection.get_timeout()
-            )
-            sender = MtProtoSender(self.session, conn)
-            sender.connect()
-
-        try:
-            # We should call receive from this thread if there's no background
-            # thread reading or if the server disconnected us and we're trying
-            # to reconnect. This is because the read thread may either be
-            # locked also trying to reconnect or we may be said thread already.
-            call_receive = not on_main_thread or \
-                self._recv_thread is None or self._connect_lock.locked()
-
-            return super().invoke(
-                *requests,
-                call_receive=call_receive,
-                retries=kwargs.get('retries', 5),
-                sender=sender
-            )
-
-        except (PhoneMigrateError, NetworkMigrateError, UserMigrateError) as e:
-            self._logger.debug('DC error when invoking request, '
-                               'attempting to reconnect at DC {}'
-                               .format(e.new_dc))
-
-            # TODO What happens with the background thread here?
-            # For normal use cases, this won't happen, because this will only
-            # be on the very first connection (not authorized, not running),
-            # but may be an issue for people who actually travel?
-            self._reconnect(new_dc=e.new_dc)
-            return self.invoke(*requests)
-
-        except ConnectionResetError as e:
-            if self._connect_lock.locked():
-                # We are connecting and we don't want to reconnect there...
-                raise
-            while self._user_connected and not self._reconnect():
-                sleep(0.1)  # Retry forever until we can send the request
-
-        finally:
-            if sender != self._sender:
-                sender.disconnect()
-
-    # Let people use client(SomeRequest()) instead client.invoke(...)
-    __call__ = invoke
-
     # region Authorization requests
-
-    def is_user_authorized(self):
-        """Has the user been authorized yet
-           (code request sent and confirmed)?"""
-        return self._authorized
 
     def send_code_request(self, phone):
         """Sends a code request to the specified phone number"""
@@ -990,75 +799,5 @@ class TelegramClient(TelegramBareClient):
         raise ValueError(
             'Cannot turn "{}" into any entity (user or chat)'.format(entity)
         )
-
-    # endregion
-
-    # region Updates handling
-
-    def sync_updates(self):
-        """Synchronizes self.updates to their initial state. Will be
-           called automatically on connection if self.updates.enabled = True,
-           otherwise it should be called manually after enabling updates.
-        """
-        self.updates.process(self(GetStateRequest()))
-
-    def add_update_handler(self, handler):
-        """Adds an update handler (a function which takes a TLObject,
-          an update, as its parameter) and listens for updates"""
-        sync = not self.updates.handlers
-        self.updates.handlers.append(handler)
-        if sync:
-            self.sync_updates()
-
-    def remove_update_handler(self, handler):
-        self.updates.handlers.remove(handler)
-
-    def list_update_handlers(self):
-        return self.updates.handlers[:]
-
-    # endregion
-
-    # Constant read
-
-    def _set_connected_and_authorized(self):
-        self._authorized = True
-        if self._recv_thread is None:
-            self._recv_thread = Thread(
-                name='ReadThread', daemon=True,
-                target=self._recv_thread_impl
-            )
-            self._recv_thread.start()
-
-    # By using this approach, another thread will be
-    # created and started upon connection to constantly read
-    # from the other end. Otherwise, manual calls to .receive()
-    # must be performed. The MtProtoSender cannot be connected,
-    # or an error will be thrown.
-    #
-    # This way, sending and receiving will be completely independent.
-    def _recv_thread_impl(self):
-        while self._user_connected:
-            try:
-                if datetime.now() > self._last_ping + self._ping_delay:
-                    self._sender.send(PingRequest(
-                        int.from_bytes(os.urandom(8), 'big', signed=True)
-                    ))
-                    self._last_ping = datetime.now()
-
-                self._sender.receive(update_state=self.updates)
-            except TimeoutError:
-                # No problem.
-                pass
-            except ConnectionResetError:
-                self._logger.debug('Server disconnected us. Reconnecting...')
-                while self._user_connected and not self._reconnect():
-                    sleep(0.1)  # Retry forever, this is instant messaging
-
-            except Exception as e:
-                # Unknown exception, pass it to the main thread
-                self.updates.set_error(e)
-                break
-
-        self._recv_thread = None
 
     # endregion

--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -57,7 +57,7 @@ class TelegramClient(TelegramBareClient):
     def __init__(self, session, api_id, api_hash,
                  connection_mode=ConnectionMode.TCP_FULL,
                  proxy=None,
-                 process_updates=False,
+                 update_workers=None,
                  timeout=timedelta(seconds=5),
                  **kwargs):
         """Initializes the Telegram client with the specified API ID and Hash.
@@ -71,11 +71,11 @@ class TelegramClient(TelegramBareClient):
            This will only affect how messages are sent over the network
            and how much processing is required before sending them.
 
-           If 'process_updates' is set to True, incoming updates will be
-           processed and you must manually call 'self.updates.poll()' from
-           another thread to retrieve the saved update objects, or your
-           memory will fill with these. You may modify the value of
-           'self.updates.polling' at any later point.
+           The integer 'update_workers' represents depending on its value:
+             is None: Updates will *not* be stored in memory.
+             = 0: Another thread is responsible for calling self.updates.poll()
+             > 0: 'update_workers' background threads will be spawned, any
+                  any of them will invoke all the self.updates.handlers.
 
            Despite the value of 'process_updates', if you later call
            '.add_update_handler(...)', updates will also be processed
@@ -94,7 +94,7 @@ class TelegramClient(TelegramBareClient):
             session, api_id, api_hash,
             connection_mode=connection_mode,
             proxy=proxy,
-            process_updates=process_updates,
+            update_workers=update_workers,
             timeout=timeout
         )
 

--- a/telethon/update_state.py
+++ b/telethon/update_state.py
@@ -1,6 +1,7 @@
+import logging
 from collections import deque
 from datetime import datetime
-from threading import RLock, Event
+from threading import RLock, Event, Thread
 
 from .tl import types as tl
 
@@ -11,13 +12,23 @@ class UpdateState:
     """
     def __init__(self, polling):
         self._polling = polling
+        self._workers = 4
+        self._worker_threads = []
+
         self.handlers = []
         self._updates_lock = RLock()
         self._updates_available = Event()
         self._updates = deque()
 
+        self._logger = logging.getLogger(__name__)
+
         # https://core.telegram.org/api/updates
         self._state = tl.updates.State(0, 0, datetime.now(), 0, 0)
+
+        # TODO Rename "polling" to some other variable
+        # that signifies "running background threads".
+        if polling:
+            self._setup_workers()
 
     def can_poll(self):
         """Returns True if a call to .poll() won't lock"""
@@ -39,16 +50,73 @@ class UpdateState:
 
         return update
 
+    # TODO How should this be handled with background worker threads?
     def get_polling(self):
         return self._polling
 
     def set_polling(self, polling):
         self._polling = polling
-        if not polling:
+        if polling:
+            self._setup_workers()
+        else:
             with self._updates_lock:
                 self._updates.clear()
+            self._stop_workers()
 
     polling = property(fget=get_polling, fset=set_polling)
+
+    def get_workers(self):
+        return self._workers
+
+    def set_workers(self, n):
+        self._stop_workers()
+        self._workers = n
+        self._setup_workers()
+
+    workers = property(fget=get_workers, fset=set_workers)
+
+    def _stop_workers(self):
+        """Raises "StopIterationException" on the worker threads to stop them,
+           and also clears all of them off the list
+        """
+        if self._worker_threads:
+            pass
+
+        self.set_error(StopIteration())
+        for t in self._worker_threads:
+            t.join()
+
+        self._worker_threads.clear()
+
+    def _setup_workers(self):
+        if self._worker_threads:
+            # There already are workers
+            return
+
+        for i in range(self._workers):
+            thread = Thread(
+                target=UpdateState._worker_loop,
+                name='UpdateWorker{}'.format(i),
+                daemon=True,
+                args=(self, i)
+            )
+            self._worker_threads.append(thread)
+            thread.start()
+
+    def _worker_loop(self, wid):
+        while True:
+            try:
+                update = self.poll()
+                # TODO Maybe people can add different handlers per update type
+                for handler in self.handlers:
+                    handler(update)
+            except StopIteration:
+                break
+            except Exception as e:
+                # We don't want to crash a worker thread due to any reason
+                self._logger.debug(
+                    '[ERROR] Unhandled exception on worker {}'.format(wid), e
+                )
 
     def set_error(self, error):
         """Sets an error, so that the next call to .poll() will raise it.
@@ -85,6 +153,3 @@ class UpdateState:
             if self._polling:
                 self._updates.append(update)
                 self._updates_available.set()
-
-        for handler in self.handlers:
-            handler(update)

--- a/telethon/update_state.py
+++ b/telethon/update_state.py
@@ -1,5 +1,4 @@
 import logging
-import threading
 from collections import deque
 from datetime import datetime
 from threading import RLock, Event, Thread
@@ -11,9 +10,15 @@ class UpdateState:
     """Used to hold the current state of processed updates.
        To retrieve an update, .poll() should be called.
     """
-    def __init__(self, polling):
-        self._polling = polling
-        self._workers = 4
+    def __init__(self, workers=None):
+        """
+        :param workers: This integer parameter has three possible cases:
+          workers is None: Updates will *not* be stored on self.
+          workers = 0: Another thread is responsible for calling self.poll()
+          workers > 0: 'workers' background threads will be spawned, any
+                       any of them will invoke all the self.handlers.
+        """
+        self._workers = workers
         self._worker_threads = []
 
         self.handlers = []
@@ -25,11 +30,7 @@ class UpdateState:
 
         # https://core.telegram.org/api/updates
         self._state = tl.updates.State(0, 0, datetime.now(), 0, 0)
-
-        # TODO Rename "polling" to some other variable
-        # that signifies "running background threads".
-        if polling:
-            self._setup_workers()
+        self._setup_workers()
 
     def can_poll(self):
         """Returns True if a call to .poll() won't lock"""
@@ -37,9 +38,6 @@ class UpdateState:
 
     def poll(self):
         """Polls an update or blocks until an update object is available"""
-        if not self._polling:
-            raise ValueError('Updates are not being polled hence not saved.')
-
         self._updates_available.wait()
         with self._updates_lock:
             if not self._updates_available.is_set():
@@ -54,28 +52,19 @@ class UpdateState:
 
         return update
 
-    # TODO How should this be handled with background worker threads?
-    def get_polling(self):
-        return self._polling
-
-    def set_polling(self, polling):
-        self._polling = polling
-        if polling:
-            self._setup_workers()
-        else:
-            with self._updates_lock:
-                self._updates.clear()
-            self._stop_workers()
-
-    polling = property(fget=get_polling, fset=set_polling)
-
     def get_workers(self):
         return self._workers
 
     def set_workers(self, n):
+        """Changes the number of workers running.
+           If 'n is None', clears all pending updates from memory.
+        """
         self._stop_workers()
         self._workers = n
-        self._setup_workers()
+        if n is None:
+            self._updates.clear()
+        else:
+            self._setup_workers()
 
     workers = property(fget=get_workers, fset=set_workers)
 
@@ -83,9 +72,6 @@ class UpdateState:
         """Raises "StopIterationException" on the worker threads to stop them,
            and also clears all of them off the list
         """
-        if self._worker_threads:
-            pass
-
         self.set_error(StopIteration())
         for t in self._worker_threads:
             t.join()
@@ -93,8 +79,8 @@ class UpdateState:
         self._worker_threads.clear()
 
     def _setup_workers(self):
-        if self._worker_threads:
-            # There already are workers
+        if self._worker_threads or not self._workers:
+            # There already are workers, or workers is None or 0. Do nothing.
             return
 
         for i in range(self._workers):
@@ -141,8 +127,8 @@ class UpdateState:
         """Processes an update object. This method is normally called by
            the library itself.
         """
-        if not self._polling and not self.handlers:
-            return
+        if self._workers is None:
+            return  # No processing needs to be done if nobody's working
 
         with self._updates_lock:
             if isinstance(update, tl.updates.State):
@@ -154,6 +140,5 @@ class UpdateState:
                 return  # We already handled this update
 
             self._state.pts = pts
-            if self._polling:
-                self._updates.append(update)
-                self._updates_available.set()
+            self._updates.append(update)
+            self._updates_available.set()

--- a/telethon/update_state.py
+++ b/telethon/update_state.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from collections import deque
 from datetime import datetime
 from threading import RLock, Event, Thread
@@ -41,6 +42,9 @@ class UpdateState:
 
         self._updates_available.wait()
         with self._updates_lock:
+            if not self._updates_available.is_set():
+                return
+
             update = self._updates.popleft()
             if not self._updates:
                 self._updates_available.clear()


### PR DESCRIPTION
There used to be a `.create_new_connection()` method, which I doubt nobody used. Now a new thread implies a new temporary connection, they're not cached anymore. Connecting is not an expensive operation anyway, and this works similarly to bot APIs need to make HTTP requests which aren't kept alive.

There is also a new way to work with updates: setting a finite amount of workers. No need to call `.poll()` from the main thread anymore.