### PR TITLE
Make find_user_or_chat work for message.id again

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -304,12 +304,16 @@ def find_user_or_chat(peer, users, chats):
        Returns None if it was not found"""
     if isinstance(peer, PeerUser):
         peer, where = peer.user_id, users
+    elif isinstance(peer, PeerChat):
+        peer, where = peer.chat_id, chats
+    elif isinstance(peer, PeerChannel):
+        peer, where = peer.channel_id, chats
     else:
-        where = chats
-        if isinstance(peer, PeerChat):
-            peer = peer.chat_id
-        elif isinstance(peer, PeerChannel):
-            peer = peer.channel_id
+        if isinstance(users, dict) and isinstance(chats, dict):
+            where = users
+            where.update(chats)
+        else:
+            where = users + chats
 
     if isinstance(peer, int):
         if isinstance(where, dict):


### PR DESCRIPTION
The recent changes in `utils.find_user_or_chat` broke the use case of finding the users of a given message. Passing `message.id` for `peer` and lists for `users` and `chats` returned `None`, even though the User I was looking for, was part of `users`.
This is for example required after a `GetDifferenceRequest` or `GetHistoryRequest` (e.g. [here](https://github.com/LonamiWebs/Telethon/blob/master/telethon/telegram_client.py#L391)). 
