### PR TITLE
add exception

### DIFF
--- a/telethon_examples/interactive_telegram_client.py
+++ b/telethon_examples/interactive_telegram_client.py
@@ -158,8 +158,11 @@ class InteractiveTelegramClient(TelegramClient):
                 # History
                 elif msg == '!h':
                     # First retrieve the messages and some information
-                    total_count, messages, senders = self.get_message_history(
+                    try:
+                        total_count, messages, senders = self.get_message_history(
                         entity, limit=10)
+                    except:
+                        continue
 
                     # Iterate over all (in reverse order so the latest appear
                     # the last in the console) and print them with format:


### PR DESCRIPTION
when pressing !h, sometimes TimeoutError and/or some other errors occurs due to network problems.
The exception prevents the script from interruption and restarts the cycle, and allows to repeat the request without reloading the script.