### PR TITLE
Fixes file downloading error

### DIFF
--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -967,6 +967,8 @@ class TelegramClient(TelegramBareClient):
                 name = None
 
             if not name:
+                if not date:
+                    date = datetime.now()
                 name = '{}_{}-{:02}-{:02}_{:02}-{:02}-{:02}'.format(
                     kind,
                     date.year, date.month, date.day,


### PR DESCRIPTION
`date`'s default value is `None`, so this function will crash if `name` is empty and `date` is not provided