### PR TITLE
telegram client: fix infinite recursion in send_file

### DIFF
--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -873,7 +873,7 @@ class TelegramClient(TelegramBareClient):
         """
         # First check if the user passed an iterable, in which case
         # we may want to send as an album if all are photo files.
-        if hasattr(file, '__iter__'):
+        if not isinstance(file, str) and hasattr(file, '__iter__'):
             # Convert to tuple so we can iterate several times
             file = tuple(x for x in file)
             if all(utils.is_image(x) for x in file):


### PR DESCRIPTION
The iterability check added in 36e21019
does not tell away strings from containers
of strings, therefore all possible arguments
are considered iterable, and the function
recurses into itself with each of the items,
which again will be considered iterable...

So doing now an explicit type check for str
before getting to itemizing. (XXX I wonder if
bytes/bytearray objects could be taken as
arguments? If yes, they should as well be
included in the type check.)