### PR TITLE
Fix update delete messages

### DIFF
--- a/readthedocs/extra/changelog.rst
+++ b/readthedocs/extra/changelog.rst
@@ -14,6 +14,35 @@ it can take advantage of new goodies!
 .. contents:: List of All Versions
 
 
+New small convenience functions (v0.17.3)
+=========================================
+
+*Published at 2018/02/18*
+
+More bug fixes and a few others addition to make events easier to use.
+
+Additions
+~~~~~~~~~
+
+- Use ``hachoir`` to extract video and audio metadata before upload.
+- New ``.add_event_handle``, ``.add_update_handler`` now deprecated.
+
+Bug fixes
+~~~~~~~~~
+
+- ``bot_token`` wouldn't work on ``.start()``, and changes to ``password``.
+- ``.edit_message()`` was ignoring the formatting (e.g. markdown).
+- Added missing case to the ``NewMessage`` event for normal groups.
+- Accessing the ``.text`` of the ``NewMessage`` event was failing due
+  to a bug with the markdown unparser.
+
+Internal changes
+~~~~~~~~~~~~~~~~
+
+- ``libssl`` is no longer an optional dependency. Use ``cryptg`` instead.
+
+
+
 New small convenience functions (v0.17.2)
 =========================================
 

--- a/telethon/events/__init__.py
+++ b/telethon/events/__init__.py
@@ -807,7 +807,7 @@ class MessageChanged(_EventBuilder):
                                  types.UpdateDeleteChannelMessages)):
             event = MessageChanged.Event(
                 deleted_ids=update.messages,
-                peer=types.PeerChannel(update.channel_id)
+                peer=types.PeerChannel(update.channel_id) if update.channel_id is not None else None
             )
         else:
             return

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -323,17 +323,19 @@ def get_input_media(media, user_caption=None, is_photo=False):
 
 def is_image(file):
     """Returns True if the file extension looks like an image file"""
-    return (mimetypes.guess_type(file)[0] or '').startswith('image/')
-
+    return (isinstance(file, str) and
+            (mimetypes.guess_type(file)[0] or '').startswith('image/'))
 
 def is_audio(file):
     """Returns True if the file extension looks like an audio file"""
-    return (mimetypes.guess_type(file)[0] or '').startswith('audio/')
+    return (isinstance(file, str) and
+            (mimetypes.guess_type(file)[0] or '').startswith('audio/'))
 
 
 def is_video(file):
     """Returns True if the file extension looks like a video file"""
-    return (mimetypes.guess_type(file)[0] or '').startswith('video/')
+    return (isinstance(file, str) and
+            (mimetypes.guess_type(file)[0] or '').startswith('video/'))
 
 
 def parse_phone(phone):

--- a/telethon/version.py
+++ b/telethon/version.py
@@ -1,3 +1,3 @@
 # Versions should comply with PEP440.
 # This line is parsed in setup.py:
-__version__ = '0.17.2'
+__version__ = '0.17.3'


### PR DESCRIPTION
For events handler, event would be built in a wrong way for UpdateDeleteMessages update type: channel_id field is not set for this type of updates
