### PR TITLE
Proxy connection fix

### DIFF
--- a/telethon/extensions/tcp_client.py
+++ b/telethon/extensions/tcp_client.py
@@ -4,6 +4,7 @@ This module holds a rough implementation of the C# TCP client.
 import errno
 import socket
 import time
+from socks import ProxyConnectionError
 from datetime import timedelta
 from io import BytesIO, BufferedWriter
 from threading import Lock
@@ -69,6 +70,8 @@ class TcpClient:
 
                 self._socket.connect(address)
                 break  # Successful connection, stop retrying to connect
+            except ProxyConnectionError:
+                raise
             except OSError as e:
                 # There are some errors that we know how to handle, and
                 # the loop will allow us to retry

--- a/telethon/extensions/tcp_client.py
+++ b/telethon/extensions/tcp_client.py
@@ -9,6 +9,11 @@ from datetime import timedelta
 from io import BytesIO, BufferedWriter
 from threading import Lock
 
+try:
+    import socks
+except ImportError:
+    socks = None
+
 MAX_TIMEOUT = 15  # in seconds
 CONN_RESET_ERRNOS = {
     errno.EBADF, errno.ENOTSOCK, errno.ENETUNREACH,
@@ -70,9 +75,10 @@ class TcpClient:
 
                 self._socket.connect(address)
                 break  # Successful connection, stop retrying to connect
-            except ProxyConnectionError:
-                raise
             except OSError as e:
+                # Stop retrying to connect if proxy connection error occurred
+                if socks and isinstance(e, socks.ProxyConnectionError):
+                    raise
                 # There are some errors that we know how to handle, and
                 # the loop will allow us to retry
                 if e.errno in (errno.EBADF, errno.ENOTSOCK, errno.EINVAL,


### PR DESCRIPTION
PySocks when connecting throws ProxyConnectionError if proxy server is unavailable. ProxyConnectionError catchs in OSError block and `e.errno` is `None`, so `getattr(errno, 'WSAEACCES', None) ` is also `None` (i use Linux) and the error is omitted that causes an infinite loop.