### PR TITLE
Fix forwarding messages to super-groups & channels.

### DIFF
--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -846,7 +846,7 @@ class TelegramClient(TelegramBareClient):
         for update in result.updates:
             if isinstance(update, UpdateMessageID):
                 random_to_id[update.random_id] = update.id
-            elif isinstance(update, UpdateNewMessage):
+            elif isinstance(update, (UpdateNewMessage, UpdateNewChannelMessage)):
                 id_to_message[update.message.id] = update.message
 
         return [id_to_message[random_to_id[rnd]] for rnd in req.random_id]


### PR DESCRIPTION
When i forward message from PM to super-group causes error: 
[`id_to_message` doesn't have `random_to_id[rnd]` key](https://github.com/LonamiWebs/Telethon/blob/master/telethon/telegram_client.py#L852) when incoming update is instance of `UpdateNewChannelMessage`
```
* part of traeback *
  File "/home/jrootjunior/PycharmProjects/farm/venv/lib/python3.6/site-packages/telethon/telegram_client.py", line 837, in forward_messages
    return [id_to_message[random_to_id[rnd]] for rnd in req.random_id]
  File "/home/jrootjunior/PycharmProjects/farm/venv/lib/python3.6/site-packages/telethon/telegram_client.py", line 837, in <listcomp>
    return [id_to_message[random_to_id[rnd]] for rnd in req.random_id]
KeyError: 315
```