### PR TITLE
Make TLObject picklable

### DIFF
--- a/telethon/tl/tlobject.py
+++ b/telethon/tl/tlobject.py
@@ -8,8 +8,9 @@ class TLObject:
         self.rpc_error = rpc_error
         self.result = result
 
-        # These should be overrode
-        self.content_related = content_related  # Only requests/functions/queries are
+        # These should be overrode.
+        # Only requests/functions/queries are content related.
+        self.content_related = content_related
 
         self._set_event()
 

--- a/telethon/tl/tlobject.py
+++ b/telethon/tl/tlobject.py
@@ -4,23 +4,25 @@ from threading import Event
 
 
 class TLObject:
-    def __init__(self, rpc_error=None, result=None, content_related=False):
-        self.rpc_error = rpc_error
-        self.result = result
+    def __init__(self):
+        self.rpc_error = None
+        self.result = None
 
-        # These should be overrode.
-        # Only requests/functions/queries are content related.
-        self.content_related = content_related
-
+        # These should be overrode
+        self.content_related = False  # Only requests/functions/queries are
         self._set_event()
 
     def _set_event(self):
         self.confirm_received = Event()
 
-    def __reduce__(self):
-        return (type(self), (self.rpc_error,
-                             self.result,
-                             self.content_related))
+    def __getstate__(self):
+        new_dct = dict(self.__dict__)
+        del new_dct["confirm_received"]
+        return new_dct
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._set_event()
 
     # These should not be overrode
     @staticmethod

--- a/telethon/tl/tlobject.py
+++ b/telethon/tl/tlobject.py
@@ -4,13 +4,22 @@ from threading import Event
 
 
 class TLObject:
-    def __init__(self):
-        self.confirm_received = Event()
-        self.rpc_error = None
-        self.result = None
+    def __init__(self, rpc_error=None, result=None, content_related=False):
+        self.rpc_error = rpc_error
+        self.result = result
 
         # These should be overrode
-        self.content_related = False  # Only requests/functions/queries are
+        self.content_related = content_related  # Only requests/functions/queries are
+
+        self._set_event()
+
+    def _set_event(self):
+        self.confirm_received = Event()
+
+    def __reduce__(self):
+        return (type(self), (self.rpc_error,
+                             self.result,
+                             self.content_related))
 
     # These should not be overrode
     @staticmethod

--- a/telethon/tl/tlobject.py
+++ b/telethon/tl/tlobject.py
@@ -10,12 +10,23 @@ class TLObject:
 
         # These should be overrode
         self.content_related = False  # Only requests/functions/queries are
+        
+        # Internal parameter to tell pickler in which state Event object was
+        self._event_is_set = False 
         self._set_event()
 
     def _set_event(self):
         self.confirm_received = Event()
+        
+        # Set Event state to 'set' if needed
+        if self._event_is_set:
+            self.confirm_received.set()
 
     def __getstate__(self):
+        # Save state of the Event object 
+        self._event_is_set = self.confirm_received.is_set()
+        
+        # Exclude Event object from dict and return new state
         new_dct = dict(self.__dict__)
         del new_dct["confirm_received"]
         return new_dct


### PR DESCRIPTION
Discussed here: [https://github.com/LonamiWebs/Telethon/issues/749](https://github.com/LonamiWebs/Telethon/issues/749)
This will work fine now:
``` python
from telethon.tl.tlobject import TLObject
import pickle

a = TLObject()
b = pickle.dumps(a)
c = pickle.loads(b)
```