### PR TITLE
add __repr__ method to TLObject

### DIFF
--- a/telethon/tl/tlobject.py
+++ b/telethon/tl/tlobject.py
@@ -152,6 +152,9 @@ class TLObject:
 
     def __str__(self):
         return TLObject.pretty_format(self)
+    
+    def __repr__(self):
+        return TLObject.pretty_format(self, indent=1)
 
     def stringify(self):
         return TLObject.pretty_format(self, indent=0)


### PR DESCRIPTION
This is useful especially when working in the interactive shell. Objects can be printed without calling `print` or `.stringify()`.