### PR TITLE
Changing self._authorized property after log_out()

### DIFF
--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -494,6 +494,7 @@ class TelegramClient(TelegramBareClient):
 
         self.disconnect()
         self.session.delete()
+        self._authorized = False
         return True
 
     def get_me(self, input_peer=False):


### PR DESCRIPTION
Making a client to `log_out()` doesn't remove the authorized status, allowing the client to bypass `client.is_user_authorized()`.