### PR TITLE
Better handling of video notes

### DIFF
--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -1632,9 +1632,12 @@ class TelegramClient(TelegramBareClient):
                             duration=int(m.get('duration').seconds
                                          if m.has('duration') else 0)
                         )
+                    elif video_note:
+                        doc = DocumentAttributeVideo(0, 1, 1,
+                                                     round_message=True)
                     else:
                         doc = DocumentAttributeVideo(0, 0, 0,
-                                                     round_message=video_note)
+                                                     round_message=False)
 
                     attr_dict[DocumentAttributeVideo] = doc
             else:

--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -1632,12 +1632,9 @@ class TelegramClient(TelegramBareClient):
                             duration=int(m.get('duration').seconds
                                          if m.has('duration') else 0)
                         )
-                    elif video_note:
-                        doc = DocumentAttributeVideo(0, 1, 1,
-                                                     round_message=True)
                     else:
-                        doc = DocumentAttributeVideo(0, 0, 0,
-                                                     round_message=False)
+                        doc = DocumentAttributeVideo(0, 1, 1,
+                                                     round_message=video_note)
 
                     attr_dict[DocumentAttributeVideo] = doc
             else:


### PR DESCRIPTION
As said in https://t.me/TelethonChat/33059 , the "0,1,1" values work better for all kind of videos, instead of the "0,0,0", which gave some problems with videos not recorded by the official apps.