### PR TITLE
AsyncIO remove filedescriptor on disconnect

### DIFF
--- a/telethon/telegram_client.py
+++ b/telethon/telegram_client.py
@@ -2436,7 +2436,7 @@ class TelegramClient(TelegramBareClient):
 
     def catch_up(self):
         state = self.session.get_update_state(0)
-        if not state:
+        if not state or not state.pts:
             return
 
         self.session.catching_up = True

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -552,8 +552,13 @@ def resolve_id(marked_id):
     if marked_id >= 0:
         return marked_id, PeerUser
 
-    if str(marked_id).startswith('-100'):
-        return int(str(marked_id)[4:]), PeerChannel
+    # There have been report of chat IDs being 10000xyz, which means their
+    # marked version is -10000xyz, which in turn looks like a channel but
+    # it becomes 00xyz (= xyz). Hence, we must assert that there are only
+    # two zeroes.
+    m = re.match(r'-100([^0]\d*)', str(marked_id))
+    if m:
+        return int(m.group(1)), PeerChannel
 
     return -marked_id, PeerChat
 

--- a/telethon_generator/generators/tlobject.py
+++ b/telethon_generator/generators/tlobject.py
@@ -466,6 +466,12 @@ def _write_arg_to_bytes(builder, arg, args, name=None):
         # Else it may be a custom type
         builder.write('bytes({})', name)
 
+        # If the type is not boxed (i.e. starts with lowercase) we should
+        # not serialize the constructor ID (so remove its first 4 bytes).
+        boxed = arg.type[arg.type.find('.') + 1].isupper()
+        if not boxed:
+            builder.write('[4:]')
+
     if arg.is_flag:
         builder.write(')')
         if arg.is_vector:


### PR DESCRIPTION
Currently the filedescriptors are not removed after disconnect, which causes an error if you have multiple clients running.

```
  fd = self._sender.connection.conn._socket.fileno()
  self._loop.remove_reader(fd)  # the filedescriptor is not removed in the normal lib
```
Add this to the disconnect function