### PR TITLE
Implement a mechanism to notify of connection failures

### DIFF
--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -219,11 +219,12 @@ class TelegramBaseClient(abc.ABC):
         return self._loop
 
     @property
-    def connection_dropped(self):
+    def disconnected(self):
         """
-        Future that resolves when the connection to Telegram ends.
+        Future that resolves when the connection to Telegram
+        ends, either by user action or in the background.
         """
-        return self._sender.connection_dropped
+        return self._sender.disconnected
 
     # endregion
 

--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -218,6 +218,13 @@ class TelegramBaseClient(abc.ABC):
     def loop(self):
         return self._loop
 
+    @property
+    def connection_dropped(self):
+        """
+        Future that resolves when the connection to Telegram ends.
+        """
+        return self._sender.connection_dropped
+
     # endregion
 
     # region Connecting

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -14,7 +14,7 @@ class UpdateMethods(UserMethods):
 
     # region Public methods
 
-    def run_loop(self):
+    def run_until_disconnected(self):
         """
         Runs the event loop until `disconnect` is called or if an error
         while connecting/sending/receiving occurs in the background. In
@@ -22,10 +22,10 @@ class UpdateMethods(UserMethods):
         to ``except`` it on your own code.
 
         This method shouldn't be called from ``async def`` as the loop
-        will be running already. Use ``await client.connection_dropped``
-        in this situation instead.
+        will be running already. Use ``await client.disconnected`` in
+        this situation instead.
         """
-        self.loop.run_until_complete(self.connection_dropped)
+        self.loop.run_until_complete(self.disconnected)
 
     def on(self, event):
         """

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -16,7 +16,9 @@ class UpdateMethods(UserMethods):
 
     def run_loop(self):
         """
-        Runs the event loop.
+        Runs the event loop until a disconnection occurs, either from
+        Telegram or by user action. If the loop is already running you
+        should ``await client.connection_dropped`` instead.
         """
         self.loop.run_until_complete(self.connection_dropped)
 

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -14,6 +14,12 @@ class UpdateMethods(UserMethods):
 
     # region Public methods
 
+    def run_loop(self):
+        """
+        Runs the event loop.
+        """
+        self.loop.run_until_complete(self.connection_dropped)
+
     def on(self, event):
         """
         Decorator helper method around add_event_handler().

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -16,9 +16,14 @@ class UpdateMethods(UserMethods):
 
     def run_loop(self):
         """
-        Runs the event loop until a disconnection occurs, either from
-        Telegram or by user action. If the loop is already running you
-        should ``await client.connection_dropped`` instead.
+        Runs the event loop until `disconnect` is called or if an error
+        while connecting/sending/receiving occurs in the background. In
+        the latter case, said error will ``raise`` so you have a chance
+        to ``except`` it on your own code.
+
+        This method shouldn't be called from ``async def`` as the loop
+        will be running already. Use ``await client.connection_dropped``
+        in this situation instead.
         """
         self.loop.run_until_complete(self.connection_dropped)
 

--- a/telethon/network/mtprotosender.py
+++ b/telethon/network/mtprotosender.py
@@ -63,6 +63,7 @@ class MTProtoSender:
         # pending futures should be cancelled.
         self._user_connected = False
         self._reconnecting = False
+        self._connection_dropped = None
 
         # We need to join the loops upon disconnection
         self._send_loop_handle = None
@@ -157,6 +158,10 @@ class MTProtoSender:
             self._recv_loop_handle.cancel()
 
         __log__.info('Disconnection from {} complete!'.format(self._ip))
+        if error is not None:
+            self._connection_dropped.set_result(None)
+        else:
+            self._connection_dropped.set_exception(error)
 
     def send(self, request, ordered=False):
         """
@@ -199,6 +204,16 @@ class MTProtoSender:
             self._send_queue.put_nowait(message)
             return message.future
 
+    @property
+    def connection_dropped(self):
+        """
+        Future that resolves when the connection to Telegram ends.
+        """
+        if self._connection_dropped is not None:
+            return self._connection_dropped
+        else:
+            raise ConnectionError('No connection yet')
+
     # Private methods
 
     async def _connect(self):
@@ -235,9 +250,10 @@ class MTProtoSender:
                 else:
                     break
             else:
-                await self._disconnect()
-                raise ConnectionError('auth_key generation failed {} times'
-                                      .format(self._retries))
+                e = ConnectionError('auth_key generation failed {} times'
+                                    .format(self._retries))
+                await self._disconnect(error=e)
+                raise e
 
         __log__.debug('Starting send loop')
         self._send_loop_handle = self._loop.create_task(self._send_loop())
@@ -245,6 +261,7 @@ class MTProtoSender:
         __log__.debug('Starting receive loop')
         self._recv_loop_handle = self._loop.create_task(self._recv_loop())
 
+        self._connection_dropped = asyncio.Future()
         __log__.info('Connection to {} complete!'.format(self._ip))
 
     async def _reconnect(self):

--- a/telethon/network/mtprotosender.py
+++ b/telethon/network/mtprotosender.py
@@ -158,10 +158,10 @@ class MTProtoSender:
             self._recv_loop_handle.cancel()
 
         __log__.info('Disconnection from {} complete!'.format(self._ip))
-        if error is not None:
-            self._connection_dropped.set_result(None)
-        else:
+        if error:
             self._connection_dropped.set_exception(error)
+        else:
+            self._connection_dropped.set_result(None)
 
     def send(self, request, ordered=False):
         """

--- a/telethon/network/mtprotosender.py
+++ b/telethon/network/mtprotosender.py
@@ -261,7 +261,9 @@ class MTProtoSender:
         __log__.debug('Starting receive loop')
         self._recv_loop_handle = self._loop.create_task(self._recv_loop())
 
-        self._connection_dropped = asyncio.Future()
+        # First connection or manual reconnection after a failure
+        if self._connection_dropped is None or self._connection_dropped.done():
+            self._connection_dropped = asyncio.Future()
         __log__.info('Connection to {} complete!'.format(self._ip))
 
     async def _reconnect(self):


### PR DESCRIPTION
Currently, upon disconnection for any reason, the event loop will just hang indefinitely because there is nothing to stop it.
This pull request adds a new interface to MTProtoSender (with a proxy in TelegramBaseClient) in the form of a future that is used to relay the disconnection event, including the error that has caused it when applicable.
It also adds a convenience method to the event API to run the event loop until that future resolves, in order to keep the API easy to use. This method is the equivalent of `idle` in the old threaded API.