### PR TITLE
fixing get_entities_text with cls

### DIFF
--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -623,7 +623,8 @@ class Message:
             return []
 
         if cls and self.original_message.entities:
-            entities_list = [c for c in self.original_message.entities if isinstance(c, cls)]
+            entities_list = [c for c in self.original_message.entities 
+                             if isinstance(c, cls)]
             texts = get_inner_text(
                 self.original_message.message,
                 entities_list

--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -625,7 +625,7 @@ class Message:
             ent = [c for c in ent if isinstance(c, cls)]
 
         texts = get_inner_text(self.original_message.message, ent)
-        return list(zip(entities_list, texts))
+        return list(zip(ent, texts))
 
     async def click(self, i=None, j=None, *, text=None, filter=None):
         """

--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -617,19 +617,21 @@ class Message:
                 >>> for _, inner_text in m.get_entities_text(MessageEntityCode):
                 >>>     print(inner_text)
         """
+        entities_list = self.original_message.entities
+        
         if not self.original_message.entities:
             return []
 
         if cls and self.original_message.entities:
+            entities_list = [c for c in self.original_message.entities if isinstance(c, cls)]
             texts = get_inner_text(
                 self.original_message.message,
-                [c for c in self.original_message.entities
-                 if isinstance(c, cls)]
+                entities_list
             )
         else:
-            texts = get_inner_text(self.original_message.message,
+            texts = get_inner_text(entities_list,
                                    self.original_message.entities)
-        return list(zip(self.original_message.entities, texts))
+        return list(zip(entities_list, texts))
 
     async def click(self, i=None, j=None, *, text=None, filter=None):
         """

--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -617,21 +617,14 @@ class Message:
                 >>> for _, inner_text in m.get_entities_text(MessageEntityCode):
                 >>>     print(inner_text)
         """
-        entities_list = self.original_message.entities
-        
         if not self.original_message.entities:
             return []
 
-        if cls and self.original_message.entities:
-            entities_list = [c for c in self.original_message.entities 
-                             if isinstance(c, cls)]
-            texts = get_inner_text(
-                self.original_message.message,
-                entities_list
-            )
-        else:
-            texts = get_inner_text(entities_list,
-                                   self.original_message.entities)
+        ent = self.original_message.entities
+        if cls and ent:
+            ent = [c for c in ent if isinstance(c, cls)]
+
+        texts = get_inner_text(self.original_message.message, ent)
         return list(zip(entities_list, texts))
 
     async def click(self, i=None, j=None, *, text=None, filter=None):


### PR DESCRIPTION
Currently the entity and text are zipped. If a cls parameter is passed, the text would have been filtered but the entities list would not be filtered, therefore the text would not correspond with the entity.