### PR TITLE
Fix bug when blank authorization code passed after prompting registered telegram user

### DIFF
--- a/telethon/client/auth.py
+++ b/telethon/client/auth.py
@@ -82,7 +82,10 @@ class AuthMethods(MessageParseMethods, UserMethods):
         """
         if code_callback is None:
             def code_callback():
-                return input('Please enter the code you received: ')
+                code = input('Please enter the code you received: ')
+                if code == '':
+                    code = 1
+                return code
         elif not callable(code_callback):
             raise ValueError(
                 'The code_callback parameter needs to be a callable '


### PR DESCRIPTION
Check to make sure user does not pass nothing when prompted for authorization code as this would result in 'Signed in successfully as ' to be printed if the phone number input was a valid & registered account.