### PR TITLE
Add method to resolve inline message IDs

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -936,6 +936,22 @@ def resolve_invite_link(link):
         return None, None, None
 
 
+def resolve_inline_message_id(inline_msg_id):
+    """
+    Resolves an inline message ID. Returns a tuple of
+    ``(dc id, message id, group id, access hash)``
+
+    Note that ``group_id`` is negated if the message originated from a channel
+    otherwise it's the (positive) ID of the sender
+
+    The ``access_hash`` isn't particularly useful, but it's unpacked nevertheless
+    """
+    try:
+        return struct.unpack('<iiiq', _decode_telegram_base64(inline_msg_id))
+    except (struct.error, TypeError):
+        return None, None, None, None
+
+
 def get_appropriated_part_size(file_size):
     """
     Gets the appropriated part size when uploading or downloading files,


### PR DESCRIPTION
Credit to @Lonami for helping with reversing this.

While the contents of an `inline_message_id` are documented [here](https://github.com/tdlib/td/blob/d9a18a064fa99130dc9214fb6131ba59e5660892/td/generate/scheme/telegram_api.tl#L613), the `id` actually contains two ints.

Its docstring probably needs some work before merging.