### PR TITLE
Allow access to result of EventBuilder's `func` predicate in event handler callbacks

### DIFF
--- a/telethon/events/common.py
+++ b/telethon/events/common.py
@@ -63,7 +63,8 @@ class EventBuilder(abc.ABC):
 
                 @client.on(events.NewMessage(func=lambda e: e.is_private))
                 async def handler(event):
-                    # Access the result of func
+                    # Access the result of func. You don't actually need the assert,
+                    # this is just an example showcasing how to access the result.
                     assert event.func_result is True
     """
     self_id = None


### PR DESCRIPTION
Initial PR where the attribute is named `func_result`, which is however open for discussion/change if necessary.