### PR TITLE
Fix file cache when using MemorySession

### DIFF
--- a/telethon/sessions/memory.py
+++ b/telethon/sessions/memory.py
@@ -235,6 +235,6 @@ class MemorySession(Session):
     def get_file(self, md5_digest, file_size, cls):
         key = (md5_digest, file_size, _SentFileType.from_type(cls))
         try:
-            return cls(self._files[key])
+            return cls(*self._files[key])
         except KeyError:
             return None


### PR DESCRIPTION
The previous version crashes as the arguments don't get unpacked correctly