### PR TITLE
Fix for utils.get_peer not raising when passed an InputPeerSelf

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -711,7 +711,8 @@ def get_peer(peer):
         elif isinstance(peer, types.InputPeerChannel):
             return types.PeerChannel(peer.channel_id)
     except (AttributeError, TypeError):
-        _raise_cast_fail(peer, 'Peer')
+        pass
+    _raise_cast_fail(peer, 'Peer')
 
 
 def get_peer_id(peer, add_mark=True):

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -728,6 +728,10 @@ def get_peer_id(peer, add_mark=True):
     if isinstance(peer, int):
         return peer if add_mark else resolve_id(peer)[0]
 
+    # Tell the user to use their client to resolve InputPeerSelf if we got one
+    if isinstance(peer, types.InputPeerSelf):
+        _raise_cast_fail(peer, 'int (you might want to use client.get_peer_id)')
+
     try:
         peer = get_peer(peer)
     except TypeError:


### PR DESCRIPTION
Currently, `utils.get_peer` returns `None` when you give it an `InputPeerSelf` object. 

Additionally `utils.get_peer_id` trusts the value from `get_peer` to not be `None`, so doing `utils.get_peer_id(types.InputPeerSelf())` causes it to raise a rather cryptic error:

![image](https://user-images.githubusercontent.com/13610073/48949832-0379e400-ef42-11e8-9f4c-363aa951251a.png)

I've added a special case for this in utils.get_peer_id as a QoL change.
