### PR TITLE
Undefined name: Typo TelegramBareClient --> TelegramBaseClient

### DIFF
--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -494,7 +494,7 @@ class TelegramBaseClient(abc.ABC):
             self._exported_sessions[cdn_redirect.dc_id] = session
 
         __log__.info('Creating new CDN client')
-        client = TelegramBareClient(
+        client = TelegramBaseClient(
             session, self.api_id, self.api_hash,
             proxy=self._sender.connection.conn.proxy,
             timeout=self._sender.connection.get_timeout()


### PR DESCRIPTION
Fixes #1051

[flake8](http://flake8.pycqa.org) testing of https://github.com/LonamiWebs/Telethon on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./telethon/client/telegrambaseclient.py:497:18: F821 undefined name 'TelegramBareClient'
        client = TelegramBareClient(
                 ^
1     F821 undefined name 'TelegramBareClient'
1
```