### PR TITLE
Extend new_algo.salt1 to fix edit_2fa

### DIFF
--- a/telethon/client/auth.py
+++ b/telethon/client/auth.py
@@ -467,6 +467,7 @@ class AuthMethods(MessageParseMethods, UserMethods):
             return False
 
         pwd = await self(functions.account.GetPasswordRequest())
+        pwd.new_algo.salt1 += os.urandom(32)
         assert isinstance(pwd, types.account.Password)
         if not pwd.has_password and current_password:
             current_password = None


### PR DESCRIPTION
Apparently the salt1 you send to the server requires an additional 32 bytes of random data. It's easy to miss this requirement from reading the tdesktop source, because this extension is done in a function called `ValidateNewCloudPasswordAlgo`.

https://github.com/telegramdesktop/tdesktop/blob/2e5a0e056cdb40d61d487c6062bffe1a835f6ddd/Telegram/SourceFiles/core/core_cloud_password.cpp#L210-L211