### PR TITLE
Make logger fully configurable

### DIFF
--- a/telethon/__init__.py
+++ b/telethon/__init__.py
@@ -1,12 +1,9 @@
-import logging
 from .client.telegramclient import TelegramClient
 from .network import connection
 from .tl import types, functions, custom
 from . import version, events, utils, errors
 
-
 __version__ = version.__version__
-logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = ['TelegramClient', 'types', 'functions', 'custom',
            'events', 'utils', 'errors']

--- a/telethon/client/downloads.py
+++ b/telethon/client/downloads.py
@@ -1,6 +1,5 @@
 import datetime
 import io
-import logging
 import os
 import pathlib
 
@@ -12,9 +11,6 @@ try:
     import aiohttp
 except ImportError:
     aiohttp = None
-
-
-__log__ = logging.getLogger(__name__)
 
 
 class DownloadMethods(UserMethods):
@@ -239,7 +235,8 @@ class DownloadMethods(UserMethods):
             # The used sender will also change if ``FileMigrateError`` occurs
             sender = self._sender
 
-        __log__.info('Downloading file in chunks of %d bytes', part_size)
+        self._log[__name__].info('Downloading file in chunks of %d bytes',
+                                 part_size)
         try:
             offset = 0
             while True:
@@ -251,7 +248,7 @@ class DownloadMethods(UserMethods):
                         # TODO Implement
                         raise NotImplementedError
                 except errors.FileMigrateError as e:
-                    __log__.info('File lives in another DC')
+                    self._log[__name__].info('File lives in another DC')
                     sender = await self._borrow_exported_sender(e.new_dc)
                     exported = True
                     continue
@@ -264,7 +261,8 @@ class DownloadMethods(UserMethods):
                     else:
                         return getattr(result, 'type', '')
 
-                __log__.debug('Saving %d more bytes', len(result.bytes))
+                self._log[__name__].debug('Saving %d more bytes',
+                                          len(result.bytes))
                 f.write(result.bytes)
                 if progress_callback:
                     progress_callback(f.tell(), file_size)

--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -1,6 +1,5 @@
 import asyncio
 import itertools
-import logging
 import time
 
 from async_generator import async_generator, yield_
@@ -10,8 +9,6 @@ from .uploads import UploadMethods
 from .buttons import ButtonMethods
 from .. import helpers, utils, errors
 from ..tl import types, functions
-
-__log__ = logging.getLogger(__name__)
 
 
 class MessageMethods(UploadMethods, ButtonMethods, MessageParseMethods):

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -1,15 +1,11 @@
 import asyncio
-import inspect
 import itertools
-import logging
 import random
 import time
 
 from .users import UserMethods
 from .. import events, utils, errors
 from ..tl import types, functions
-
-__log__ = logging.getLogger(__name__)
 
 
 class UpdateMethods(UserMethods):
@@ -281,28 +277,31 @@ class UpdateMethods(UserMethods):
                 await callback(event)
             except errors.AlreadyInConversationError:
                 name = getattr(callback, '__name__', repr(callback))
-                __log__.debug('Event handler "%s" already has an open '
-                              'conversation, ignoring new one', name)
+                self._log[__name__].debug(
+                    'Event handler "%s" already has an open conversation, '
+                    'ignoring new one', name)
             except events.StopPropagation:
                 name = getattr(callback, '__name__', repr(callback))
-                __log__.debug(
+                self._log[__name__].debug(
                     'Event handler "%s" stopped chain of propagation '
                     'for event %s.', name, type(event).__name__
                 )
                 break
             except Exception:
                 name = getattr(callback, '__name__', repr(callback))
-                __log__.exception('Unhandled exception on %s', name)
+                self._log[__name__].exception('Unhandled exception on %s',
+                                              name)
 
     async def _handle_auto_reconnect(self):
         # Upon reconnection, we want to send getState
         # for Telegram to keep sending us updates.
         try:
-            __log__.info('Asking for the current state after reconnect...')
+            self._log[__name__].info(
+                'Asking for the current state after reconnect...')
             state = await self(functions.updates.GetStateRequest())
-            __log__.info('Got new state! %s', state)
+            self._log[__name__].info('Got new state! %s', state)
         except errors.RPCError as e:
-            __log__.info('Failed to get current state: %r', e)
+            self._log[__name__].info('Failed to get current state: %r', e)
 
     # endregion
 

--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -1,6 +1,5 @@
 import hashlib
 import io
-import logging
 import os
 import pathlib
 import re
@@ -11,8 +10,6 @@ from .messageparse import MessageParseMethods
 from .users import UserMethods
 from .. import utils, helpers
 from ..tl import types, functions, custom
-
-__log__ = logging.getLogger(__name__)
 
 
 class _CacheType:
@@ -196,8 +193,8 @@ class UploadMethods(ButtonMethods, MessageParseMethods, UserMethods):
         return msg
 
     async def _send_album(self, entity, files, caption='',
-                    progress_callback=None, reply_to=None,
-                    parse_mode=(), silent=None):
+                          progress_callback=None, reply_to=None,
+                          parse_mode=(), silent=None):
         """Specialized version of .send_file for albums"""
         # We don't care if the user wants to avoid cache, we will use it
         # anyway. Why? The cached version will be exactly the same thing
@@ -350,8 +347,8 @@ class UploadMethods(ButtonMethods, MessageParseMethods, UserMethods):
                     return cached
 
         part_count = (file_size + part_size - 1) // part_size
-        __log__.info('Uploading file of %d bytes in %d chunks of %d',
-                     file_size, part_count, part_size)
+        self._log[__name__].info('Uploading file of %d bytes in %d chunks of %d',
+                                 file_size, part_count, part_size)
 
         with open(file, 'rb') if isinstance(file, str) else BytesIO(file)\
                 as stream:
@@ -370,8 +367,8 @@ class UploadMethods(ButtonMethods, MessageParseMethods, UserMethods):
 
                 result = await self(request)
                 if result:
-                    __log__.debug('Uploaded %d/%d', part_index + 1,
-                                  part_count)
+                    self._log[__name__].debug('Uploaded %d/%d',
+                                              part_index + 1, part_count)
                     if progress_callback:
                         progress_callback(stream.tell(), file_size)
                 else:
@@ -464,7 +461,7 @@ class UploadMethods(ButtonMethods, MessageParseMethods, UserMethods):
         return file_handle, media
 
     async def _cache_media(self, msg, file, file_handle,
-                     force_document=False):
+                           force_document=False):
         if file and msg and isinstance(file_handle,
                                        custom.InputSizedFile):
             # There was a response message and we didn't use cached

--- a/telethon/extensions/messagepacker.py
+++ b/telethon/extensions/messagepacker.py
@@ -1,14 +1,11 @@
 import asyncio
 import collections
 import io
-import logging
 import struct
 
 from ..tl import TLRequest
 from ..tl.core.messagecontainer import MessageContainer
 from ..tl.core.tlmessage import TLMessage
-
-__log__ = logging.getLogger(__name__)
 
 
 class MessagePacker:
@@ -24,11 +21,13 @@ class MessagePacker:
     encryption and network overhead also is smaller. It's also a central
     point where outgoing requests are put, and where ready-messages are get.
     """
-    def __init__(self, state, loop):
+
+    def __init__(self, state, loop, loggers):
         self._state = state
         self._loop = loop
         self._deque = collections.deque()
         self._ready = asyncio.Event(loop=loop)
+        self._log = loggers[__name__]
 
     def append(self, state):
         self._deque.append(state)
@@ -65,9 +64,9 @@ class MessagePacker:
                     after_id=state.after.msg_id if state.after else None
                 )
                 batch.append(state)
-                __log__.debug('Assigned msg_id = %d to %s (%x)',
-                              state.msg_id, state.request.__class__.__name__,
-                              id(state.request))
+                self._log.debug('Assigned msg_id = %d to %s (%x)',
+                                state.msg_id, state.request.__class__.__name__,
+                                id(state.request))
                 continue
 
             # Put the item back since it can't be sent in this batch

--- a/telethon/network/connection/connection.py
+++ b/telethon/network/connection/connection.py
@@ -1,12 +1,9 @@
 import abc
 import asyncio
-import logging
 import socket
 import ssl as ssl_mod
 
 from ...errors import InvalidChecksumError
-
-__log__ = logging.getLogger(__name__)
 
 
 class Connection(abc.ABC):
@@ -21,10 +18,11 @@ class Connection(abc.ABC):
     ``ConnectionError``, which will raise when attempting to send if
     the client is disconnected (includes remote disconnections).
     """
-    def __init__(self, ip, port, *, loop, proxy=None):
+    def __init__(self, ip, port, *, loop, loggers, proxy=None):
         self._ip = ip
         self._port = port
         self._loop = loop
+        self._log = loggers[__name__]
         self._proxy = proxy
         self._reader = None
         self._writer = None
@@ -156,13 +154,13 @@ class Connection(abc.ABC):
             except Exception as e:
                 if isinstance(e, (ConnectionError, asyncio.IncompleteReadError)):
                     msg = 'The server closed the connection'
-                    __log__.info(msg)
+                    self._log.info(msg)
                 elif isinstance(e, InvalidChecksumError):
                     msg = 'The server response had an invalid checksum'
-                    __log__.info(msg)
+                    self._log.info(msg)
                 else:
                     msg = 'Unexpected exception in the receive loop'
-                    __log__.exception(msg)
+                    self._log.exception(msg)
 
                 self.disconnect()
 

--- a/telethon/network/connection/tcpfull.py
+++ b/telethon/network/connection/tcpfull.py
@@ -10,8 +10,8 @@ class ConnectionTcpFull(Connection):
     Default Telegram mode. Sends 12 additional bytes and
     needs to calculate the CRC value of the packet itself.
     """
-    def __init__(self, ip, port, *, loop, proxy=None):
-        super().__init__(ip, port, loop=loop, proxy=proxy)
+    def __init__(self, ip, port, *, loop, loggers, proxy=None):
+        super().__init__(ip, port, loop=loop, loggers=loggers, proxy=proxy)
         self._send_counter = 0
 
     async def connect(self, timeout=None, ssl=None):

--- a/telethon/network/connection/tcpobfuscated.py
+++ b/telethon/network/connection/tcpobfuscated.py
@@ -10,8 +10,8 @@ class ConnectionTcpObfuscated(ConnectionTcpAbridged):
     every message with a randomly generated key using the
     AES-CTR mode so the packets are harder to discern.
     """
-    def __init__(self, ip, port, *, loop, proxy=None):
-        super().__init__(ip, port, loop=loop, proxy=proxy)
+    def __init__(self, ip, port, *, loop, loggers, proxy=None):
+        super().__init__(ip, port, loop=loop, loggers=loggers, proxy=proxy)
         self._aes_encrypt = None
         self._aes_decrypt = None
 

--- a/telethon/network/mtprotostate.py
+++ b/telethon/network/mtprotostate.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import struct
 import time
@@ -10,8 +9,6 @@ from ..extensions import BinaryReader
 from ..tl.core import TLMessage
 from ..tl.functions import InvokeAfterMsgRequest
 from ..tl.core.gzippacked import GzipPacked
-
-__log__ = logging.getLogger(__name__)
 
 
 class MTProtoState:
@@ -37,8 +34,9 @@ class MTProtoState:
     many methods that would be needed to make it convenient to use for the
     authentication process, at which point the `MTProtoPlainSender` is better.
     """
-    def __init__(self, auth_key):
+    def __init__(self, auth_key, loggers):
         self.auth_key = auth_key
+        self._log = loggers[__name__]
         self.time_offset = 0
         self.salt = 0
         self.reset()
@@ -183,7 +181,7 @@ class MTProtoState:
 
         if self.time_offset != old:
             self._last_msg_id = 0
-            __log__.debug(
+            self._log.debug(
                 'Updated time offset (old offset %d, bad %d, good %d, new %d)',
                 old, bad, correct_msg_id, self.time_offset
             )

--- a/telethon/tl/core/messagecontainer.py
+++ b/telethon/tl/core/messagecontainer.py
@@ -1,10 +1,5 @@
-import logging
-import struct
-
 from .tlmessage import TLMessage
 from ..tlobject import TLObject
-
-__log__ = logging.getLogger(__name__)
 
 
 class MessageContainer(TLObject):

--- a/telethon/tl/core/tlmessage.py
+++ b/telethon/tl/core/tlmessage.py
@@ -1,8 +1,4 @@
-import logging
-
 from .. import TLObject
-
-__log__ = logging.getLogger(__name__)
 
 
 class TLMessage(TLObject):


### PR DESCRIPTION
Add option to pass own logger instance or name to TelegramBaseClient that is then propagated to everything else.