### PR TITLE
 Initial implementation of MTProxy connection support

### DIFF
--- a/telethon/network/__init__.py
+++ b/telethon/network/__init__.py
@@ -6,6 +6,6 @@ from .mtprotoplainsender import MTProtoPlainSender
 from .authenticator import do_authentication
 from .mtprotosender import MTProtoSender
 from .connection import (
-    ConnectionTcpFull, ConnectionTcpAbridged, ConnectionTcpObfuscated,
-    ConnectionTcpIntermediate, ConnectionHttp
+    ConnectionTcpFull, ConnectionTcpIntermediate, ConnectionTcpAbridged,
+    ConnectionTcpObfuscated, ConnectionTcpMTProxy, ConnectionHttp
 )

--- a/telethon/network/authenticator.py
+++ b/telethon/network/authenticator.py
@@ -10,7 +10,7 @@ from ..tl.types import (
     ResPQ, PQInnerData, ServerDHParamsFail, ServerDHParamsOk,
     ServerDHInnerData, ClientDHInnerData, DhGenOk, DhGenRetry, DhGenFail
 )
-from .. import helpers as utils
+from .. import helpers
 from ..crypto import AES, AuthKey, Factorization, rsa
 from ..errors import SecurityError
 from ..extensions import BinaryReader
@@ -94,7 +94,7 @@ async def do_authentication(sender):
         'Step 2.2 answer was %s' % server_dh_params
 
     # Step 3 sending: Complete DH Exchange
-    key, iv = utils.generate_key_data_from_nonce(
+    key, iv = helpers.generate_key_data_from_nonce(
         res_pq.server_nonce, new_nonce
     )
     if len(server_dh_params.encrypted_answer) % 16 != 0:

--- a/telethon/network/connection/__init__.py
+++ b/telethon/network/connection/__init__.py
@@ -1,5 +1,6 @@
 from .tcpfull import ConnectionTcpFull
+from .tcpintermediate import ConnectionTcpIntermediate
 from .tcpabridged import ConnectionTcpAbridged
 from .tcpobfuscated import ConnectionTcpObfuscated
-from .tcpintermediate import ConnectionTcpIntermediate
+from .tcpmtproxy import ConnectionTcpMTProxy
 from .http import ConnectionHttp

--- a/telethon/network/connection/connection.py
+++ b/telethon/network/connection/connection.py
@@ -18,9 +18,10 @@ class Connection(abc.ABC):
     ``ConnectionError``, which will raise when attempting to send if
     the client is disconnected (includes remote disconnections).
     """
-    def __init__(self, ip, port, *, loop, loggers, proxy=None):
+    def __init__(self, ip, port, dc_id, *, loop, loggers, proxy=None):
         self._ip = ip
         self._port = port
+        self._dc_id = dc_id  # only for MTProxy, it's an abstraction leak
         self._loop = loop
         self._log = loggers[__name__]
         self._proxy = proxy
@@ -98,7 +99,9 @@ class Connection(abc.ABC):
         """
         Creates a clone of the connection.
         """
-        return self.__class__(self._ip, self._port, loop=self._loop)
+        # TODO: Should we pass proxy?
+        return self.__class__(
+            self._ip, self._port, self._dc_id, loop=self._loop)
 
     def send(self, data):
         """

--- a/telethon/network/connection/connection.py
+++ b/telethon/network/connection/connection.py
@@ -95,14 +95,6 @@ class Connection(abc.ABC):
         if self._writer:
             self._writer.close()
 
-    def clone(self):
-        """
-        Creates a clone of the connection.
-        """
-        # TODO: Should we pass proxy?
-        return self.__class__(
-            self._ip, self._port, self._dc_id, loop=self._loop)
-
     def send(self, data):
         """
         Sends a packet of data through this connection mode.

--- a/telethon/network/connection/tcpfull.py
+++ b/telethon/network/connection/tcpfull.py
@@ -10,8 +10,9 @@ class ConnectionTcpFull(Connection):
     Default Telegram mode. Sends 12 additional bytes and
     needs to calculate the CRC value of the packet itself.
     """
-    def __init__(self, ip, port, *, loop, loggers, proxy=None):
-        super().__init__(ip, port, loop=loop, loggers=loggers, proxy=proxy)
+    def __init__(self, ip, port, dc_id, *, loop, loggers, proxy=None):
+        super().__init__(
+            ip, port, dc_id, loop=loop, loggers=loggers, proxy=proxy)
         self._send_counter = 0
 
     async def connect(self, timeout=None, ssl=None):

--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -1,0 +1,40 @@
+import hashlib
+
+from .tcpobfuscated import ConnectionTcpObfuscated
+from ...crypto import AESModeCTR
+
+
+class ConnectionTcpMTProxy(ConnectionTcpObfuscated):
+    """
+    Wrapper around the "obfuscated2" mode that modifies it a little and allows
+    user to connect to the Telegram proxy servers commonly known as MTProxy.
+    Implemented very ugly due to the leaky abstractions in Telethon networking
+    classes that should be refactored later (TODO).
+    """
+    @staticmethod
+    def address_info(proxy_info):
+        if proxy_info is None:
+            raise ValueError("No proxy info specified for MTProxy connection")
+        return proxy_info[:2]
+
+    def __init__(self, ip, port, dc_id, *, loop, loggers, proxy=None):
+        proxy_host, proxy_port = self.address_info(proxy)
+        super().__init__(
+            proxy_host, proxy_port, dc_id, loop=loop, loggers=loggers)
+
+        # TODO: Implement the dd-secret secure mode (adds noise to fool DPI)
+        self._secret = bytes.fromhex(proxy[2])
+        if len(self._secret) != 16:
+            raise ValueError(
+                "MTProxy secure mode is not implemented for now, sorry"
+                if len(self._secret) == 17 and self._secret[0] == 0xDD else
+                "MTProxy secret must be a hex-string representing 16 bytes"
+            )
+
+    def _compose_key(self, data):
+        return hashlib.sha256(data + self._secret).digest()
+
+    def _compose_tail(self, data):
+        dc_id_bytes = self._dc_id.to_bytes(2, "little", signed=True)
+        tail_bytes = super()._compose_tail(data)
+        return tail_bytes[:4] + dc_id_bytes + tail_bytes[6:]

--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -26,7 +26,7 @@ class ConnectionTcpMTProxy(ConnectionTcpObfuscated):
         self._secret = bytes.fromhex(proxy[2])
         if len(self._secret) != 16:
             raise ValueError(
-                "MTProxy secure mode is not implemented for now, sorry"
+                "MTProxy secure mode is not implemented for now"
                 if len(self._secret) == 17 and self._secret[0] == 0xDD else
                 "MTProxy secret must be a hex-string representing 16 bytes"
             )

--- a/telethon/network/connection/tcpobfuscated.py
+++ b/telethon/network/connection/tcpobfuscated.py
@@ -7,12 +7,14 @@ from ...crypto import AESModeCTR
 
 class ConnectionTcpObfuscated(ConnectionTcpAbridged):
     """
-    Encodes the packet just like `ConnectionTcpAbridged`, but encrypts
-    every message with a randomly generated key using the
-    AES-CTR mode so the packets are harder to discern.
+    Mode that Telegram defines as "obfuscated2". Encodes the packet
+    just like `ConnectionTcpAbridged`, but encrypts every message with
+    a randomly generated key using the AES-CTR mode so the packets are
+    harder to discern.
     """
-    def __init__(self, ip, port, *, loop, loggers, proxy=None):
-        super().__init__(ip, port, loop=loop, loggers=loggers, proxy=proxy)
+    def __init__(self, ip, port, dc_id, *, loop, loggers, proxy=None):
+        super().__init__(
+            ip, port, dc_id, loop=loop, loggers=loggers, proxy=proxy)
         self._aes_encrypt = None
         self._aes_decrypt = None
 
@@ -40,14 +42,22 @@ class ConnectionTcpObfuscated(ConnectionTcpAbridged):
         random_reversed = random[55:7:-1]  # Reversed (8, len=48)
 
         # Encryption has "continuous buffer" enabled
-        encrypt_key = bytes(random[8:40])
+        encrypt_key = self._compose_key(bytes(random[8:40]))
         encrypt_iv = bytes(random[40:56])
-        decrypt_key = bytes(random_reversed[:32])
+        decrypt_key = self._compose_key(bytes(random_reversed[:32]))
         decrypt_iv = bytes(random_reversed[32:48])
 
         self._aes_encrypt = AESModeCTR(encrypt_key, encrypt_iv)
         self._aes_decrypt = AESModeCTR(decrypt_key, decrypt_iv)
 
-        random[56:64] = self._aes_encrypt.encrypt(bytes(random))[56:64]
+        random[56:64] = self._compose_tail(bytes(random))
         self._writer.write(random)
         await self._writer.drain()
+
+    # Next functions provide the variable parts of the connection handshake.
+    # This is necessary to modify obfuscated2 the way that MTProxy requires.
+    def _compose_key(self, data):
+        return data
+
+    def _compose_tail(self, data):
+        return self._aes_encrypt.encrypt(data)[56:64]


### PR DESCRIPTION
This (partially) closes #823.
Important notes:
* Implementation is rough due to inconsistencies in the network abstractions in Telethon, hope I'll try to refactor them later.
* This doesn't support dd-secure mode for now since it's damn undocumented and I failed to find any understandable hint.

Reference articles and links that were very helpful:
* English
  * https://github.com/alexbers/mtprotoproxy
  * https://github.com/9seconds/mtg#secure-mode
  * https://blog.susanka.eu/how-telegram-obfuscates-its-mtproto-traffic/
* Russian
  * https://telegra.ph/telegram-blocks-wtf-05-26
  * https://habr.com/ru/post/359348/
  * https://habr.com/ru/post/414099/
  * https://habr.com/ru/post/414139/

Many thanks to @aprosvetova aka **koteeq**.