### PR TITLE
Fix RequestIter.__anext__ without __ainit__

### DIFF
--- a/telethon/requestiter.py
+++ b/telethon/requestiter.py
@@ -32,11 +32,11 @@ class RequestIter(abc.ABC):
         self.wait_time = wait_time
         self.kwargs = kwargs
         self.limit = max(float('inf') if limit is None else limit, 0)
-        self.left = None
+        self.left = self.limit
         self.buffer = None
-        self.index = None
+        self.index = 0
         self.total = None
-        self.last_load = None
+        self.last_load = 0
 
     async def _init(self, **kwargs):
         """


### PR DESCRIPTION
There are problems with:
```Traceback (most recent call last)
<ipython-input-25-2ba447b078db> in async-def-wrapper()
      1 it = client.iter_messages(entity)
      2 with suppress(StopAsyncIteration):
----> 3     chunk = [await it.__anext__()]
      4 if it.total > 1:
      5     async for message in it:

/usr/local/lib/python3.7/dist-packages/telethon/requestiter.py in __anext__(self)
     59                 self.left = len(self.buffer)
     60 
---> 61         if self.left <= 0:  # <= 0 because subclasses may change it
     62             raise StopAsyncIteration
     63 

TypeError: '<=' not supported between instances of 'NoneType' and 'int'
```
The following works correctly:
```python
it = client.iter_messages(entity).__aiter__()
with suppress(StopAsyncIteration):
    chunk = [await it.__anext__()]
if it.total > 1:
    async for message in it:
        await asyncio.sleep(0)
```
I don't no which purpose for `self.left` so it needs to be reviewed.