### PR TITLE
Fix mtproxy dd-mode

### DIFF
--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -36,7 +36,7 @@ class MTProxyIO:
         if is_dd and not is_rand_codec:
             raise ValueError(
                 "Only RandomizedIntermediate can be used with dd-secrets")
-        secret = secret[:-1] if is_dd else secret
+        secret = secret[1:] if is_dd else secret
         if len(secret) != 16:
             raise ValueError(
                 "MTProxy secret must be a hex-string representing 16 bytes")


### PR DESCRIPTION
Below is the result for the current master. Currently we're cutting off last secret's byte while we're definitely meant to cut the 'dd' part of it.

<img width="804" alt="image" src="https://user-images.githubusercontent.com/1161827/56441850-0e6d5080-62f7-11e9-96c7-5e37b325d4d2.png">

Here we're able to login after fixing dd part

<img width="930" alt="image" src="https://user-images.githubusercontent.com/1161827/56441958-7e7bd680-62f7-11e9-9fbe-e1cced903d68.png">

