### PR TITLE
Add a convenience method for editing admin rights and permissions

### DIFF
--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -855,7 +855,7 @@ class ChatMethods(UserMethods):
         else:
             raise ValueError('You must pass either a channel or a supergroup or a normal group')
 
-    async def edit_permission(
+    async def edit_restriction(
             self: 'TelegramClient',
             entity: 'hints.EntityLike',
             user: 'typing.Optional[hints.EntityLike]' = None,
@@ -950,17 +950,17 @@ class ChatMethods(UserMethods):
                     peer=entity,
                     banned_rights=types.ChatBannedRights(
                         until_date=until_date,
-                        view_messages=view_messages,
-                        send_messages=send_messages,
-                        send_media=send_media,
-                        send_stickers=send_stickers,
-                        send_gifs=send_gifs,
-                        send_games=send_games,
-                        send_inline=send_inline,
-                        send_polls=send_polls,
-                        change_info=change_info,
-                        invite_users=invite_users,
-                        pin_messages=pin_messages
+                        view_messages=False if view_messages is True else True if view_messages is False else None,
+                        send_messages=False if send_messages is True else True if send_messages is False else None,
+                        send_media=False if send_media is True else True if send_media is False else None,
+                        send_stickers=False if send_stickers is True else True if send_stickers is False else None,
+                        send_gifs=False if send_gifs is True else True if send_gifs is False else None,
+                        send_games=False if send_games is True else True if send_games is False else None,
+                        send_inline=False if send_inline is True else True if send_inline is False else None,
+                        send_polls=False if send_polls is True else True if send_polls is False else None,
+                        change_info=False if change_info is True else True if change_info is False else None,
+                        invite_users=False if invite_users is True else True if invite_users is False else None,
+                        pin_messages=False if pin_messages is True else True if pin_messages is False else None
                     )
                 ))
         else:
@@ -972,18 +972,17 @@ class ChatMethods(UserMethods):
                 channel=entity,
                 user_id=user,
                 banned_rights=types.ChatBannedRights(
-                    until_date=until_date,
-                    view_messages=view_messages,
-                    send_messages=send_messages,
-                    send_media=send_media,
-                    send_stickers=send_stickers,
-                    send_gifs=send_gifs,
-                    send_games=send_games,
-                    send_inline=send_inline,
-                    send_polls=send_polls,
-                    change_info=change_info,
-                    invite_users=invite_users,
-                    pin_messages=pin_messages
+                    view_messages=False if view_messages is True else True if view_messages is False else None,
+                    send_messages=False if send_messages is True else True if send_messages is False else None,
+                    send_media=False if send_media is True else True if send_media is False else None,
+                    send_stickers=False if send_stickers is True else True if send_stickers is False else None,
+                    send_gifs=False if send_gifs is True else True if send_gifs is False else None,
+                    send_games=False if send_games is True else True if send_games is False else None,
+                    send_inline=False if send_inline is True else True if send_inline is False else None,
+                    send_polls=False if send_polls is True else True if send_polls is False else None,
+                    change_info=False if change_info is True else True if change_info is False else None,
+                    invite_users=False if invite_users is True else True if invite_users is False else None,
+                    pin_messages=False if pin_messages is True else True if pin_messages is False else None
                 )
             ))
 

--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -871,7 +871,7 @@ class ChatMethods(UserMethods):
         else:
             raise ValueError('You can only edit permissions in groups and channels')
 
-    async def edit_restriction(
+    async def edit_restrictions(
             self: 'TelegramClient',
             entity: 'hints.EntityLike',
             user: 'typing.Optional[hints.EntityLike]' = None,

--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -959,7 +959,7 @@ class ChatMethods(UserMethods):
                 client.edit_permission(chat, user, view_messages=False)
         """
         entity = await self.get_input_entity(entity)
-        if not isinstance(entity,types.InputPeerChannel):
+        if not isinstance(entity, types.InputPeerChannel):
             raise ValueError('You must pass either a channel or a supergroup')
 
         rights = types.ChatBannedRights(

--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -762,4 +762,169 @@ class ChatMethods(UserMethods):
         return _ChatAction(
             self, entity, action, delay=delay, auto_cancel=auto_cancel)
 
+    async def edit_admin(
+            self: 'TelegramClient',
+            entity: 'hints.EntityLike',
+            user: 'hints.EntityLike',
+            change_info: bool = None,
+            post_messages: bool = None,
+            edit_messages: bool = None,
+            delete_messages: bool = None,
+            ban_users: bool = None,
+            invite_users: bool = None,
+            pin_messages: bool = None,
+            add_admins: bool = None,
+            is_admin: bool = None) -> types.Updates:
+        """
+        Edits admin permissions for the given entity
+        will raise an error if wrong combination of rights are given
+        Arguments
+            entity (`entity`):
+                Either a channel or a supergroup or a chat.
+            user (`entity`):
+                the user to be promoted
+            change_info (`bool`, optional):
+                Whether the user will be able to change info. works in channels and supergroups.
+            post_messages (`bool`, optional):
+                Whether the user will be able to post in the channel. only works in channels.
+            edit_messages (`bool`, optional):
+                Whether the user will be able to edit messages in the channel. only works in channels.
+            delete_messages (`bool`, optional):
+                Whether the user will be able to delete messages. works in channels and supergroups.
+            ban_users (`bool`, optional):
+                Whether the user will be able to ban users. works in channels and supergroups.
+            invite_users (`bool`, optional):
+                Whether the user will be able to invite users. Needs some testing.
+            pin_messages (`bool`, optional):
+                Whether the user will be able to pin messages. works in channels and supergroups.
+            add_admins (`bool`, optional):
+                Whether the user will be able to add admins. works in channels and supergroups.
+            is_admin (`bool`, optional):
+                Whether the user will be an admin in the chat. only works in chats.
+        Returns
+            returns an Updates object.
+        """
+        entity = await self.get_input_entity(entity)
+        user = await self.get_input_entity(user)
+        if not isinstance(user, types.InputPeerUser):
+            raise ValueError("You must pass a user entity")
+        if isinstance(entity, types.InputPeerChannel):
+            result = await self(functions.channels.EditAdminRequest(
+                entity,
+                user,
+                types.ChatAdminRights(
+                    change_info=change_info,
+                    post_messages=post_messages,
+                    edit_messages=edit_messages,
+                    delete_messages=delete_messages,
+                    ban_users=ban_users,
+                    invite_users=invite_users,
+                    pin_messages=pin_messages,
+                    add_admins=add_admins
+                )
+            ))
+        elif isinstance(entity, types.InputPeerChat):
+            result = await self(functions.messages.EditChatAdminRequest(entity, user, is_admin=is_admin))
+        else:
+            raise ValueError("You must pass either a channel or a supergroup or a normal group")
+        return result
+
+    async def edit_permission(
+            self: 'TelegramClient',
+            entity: 'hints.EntityLike',
+            user: 'typing.Optional[hints.EntityLike]' = None,
+            until_date: 'hints.DateLike' = None,
+            view_messages: bool = None,
+            send_messages: bool = None,
+            send_media: bool = None,
+            send_stickers: bool = None,
+            send_gifs: bool = None,
+            send_games: bool = None,
+            send_inline: bool = None,
+            send_polls: bool = None,
+            change_info: bool = None,
+            invite_users: bool = None,
+            pin_messages: bool = None) -> types.Updates:
+        """
+        Edits user permissions or channel/supergroup global permission for the given entity
+        will raise an error if wrong combination of rights are given
+        Arguments
+            entity (`entity`):
+                Either a channel or a supergroup.
+            user (`entity`,optional):
+                If passed the permission will be changed for the specific user instead of the whole entity.
+            until_date (`DateLike`, optional):
+                Date when the user will be unbanned, unix time.
+                If user is banned for more than 366 days or less than 30 seconds from the current time they are
+                considered to be banned forever. Defaults to 0 (ban forever).
+            view_messages (`bool`, optional):
+                If this is set to False the user will be banned. only usable when a user entity is passed.
+            send_messages (`bool`, optional):
+                Permission to send messages in the channel/supergroup.
+            send_media (`bool`, optional):
+                Permission to send media files in the channel/supergroup.
+            send_stickers (`bool`, optional):
+                Permission to send stickers in the channel/supergroup.
+            send_gifs (`bool`, optional):
+                Permission to send stickers in the channel/supergroup.
+            send_games (`bool`, optional):
+                Permission to link games in the channel/supergroup.
+            send_inline (`bool`, optional):
+                Permission to use inline bots in the channel/supergroup.
+            send_polls (`bool`, optional):
+                Permission to send polls in the channel/supergroup.
+            change_info (`bool`, optional):
+                Permission to change channel/supergroup info.
+            invite_users (`bool`, optional):
+                Permission to invite users to the channel/supergroup.
+            pin_messages (`bool`, optional):
+                Permission to pin messages in the channel/supergroup.
+        Returns
+            returns an Updates object.
+        """
+        entity = await self.get_input_entity(entity)
+        if not isinstance(entity,types.InputPeerChannel):
+            raise ValueError("You must pass either a channel or a supergroup")
+        else:
+            if user is None:
+                result = await self(functions.messages.EditChatDefaultBannedRightsRequest(
+                        peer=entity,
+                        banned_rights=types.ChatBannedRights(
+                            until_date=until_date,
+                            view_messages=view_messages,
+                            send_messages=send_messages,
+                            send_media=send_media,
+                            send_stickers=send_stickers,
+                            send_gifs=send_gifs,
+                            send_games=send_games,
+                            send_inline=send_inline,
+                            send_polls=send_polls,
+                            change_info=change_info,
+                            invite_users=invite_users,
+                            pin_messages=pin_messages
+                        )
+                    ))
+            else:
+                user = await self.get_input_entity(user)
+                if not isinstance(user, types.InputPeerUser):
+                    raise ValueError("You must pass a user entity")
+                result = await self(functions.channels.EditBannedRequest(
+                    channel=entity,
+                    user_id=user,
+                    banned_rights=types.ChatBannedRights(
+                        until_date=until_date,
+                        view_messages=view_messages,
+                        send_messages=send_messages,
+                        send_media=send_media,
+                        send_stickers=send_stickers,
+                        send_gifs=send_gifs,
+                        send_games=send_games,
+                        send_inline=send_inline,
+                        send_polls=send_polls,
+                        change_info=change_info,
+                        invite_users=invite_users,
+                        pin_messages=pin_messages
+                    )
+                ))
+        return result
     # endregion

--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -861,17 +861,17 @@ class ChatMethods(UserMethods):
             user: 'typing.Optional[hints.EntityLike]' = None,
             until_date: 'hints.DateLike' = None,
             *,
-            view_messages: bool = None,
-            send_messages: bool = None,
-            send_media: bool = None,
-            send_stickers: bool = None,
-            send_gifs: bool = None,
-            send_games: bool = None,
-            send_inline: bool = None,
-            send_polls: bool = None,
-            change_info: bool = None,
-            invite_users: bool = None,
-            pin_messages: bool = None) -> types.Updates:
+            view_messages: bool = True,
+            send_messages: bool = True,
+            send_media: bool = True,
+            send_stickers: bool = True,
+            send_gifs: bool = True,
+            send_games: bool = True,
+            send_inline: bool = True,
+            send_polls: bool = True,
+            change_info: bool = True,
+            invite_users: bool = True,
+            pin_messages: bool = True) -> types.Updates:
         """
         Edits user restrictions in a chat.
 
@@ -945,45 +945,36 @@ class ChatMethods(UserMethods):
         entity = await self.get_input_entity(entity)
         if not isinstance(entity,types.InputPeerChannel):
             raise ValueError('You must pass either a channel or a supergroup')
-        elif user is None:
-            return await self(functions.messages.EditChatDefaultBannedRightsRequest(
-                    peer=entity,
-                    banned_rights=types.ChatBannedRights(
-                        until_date=until_date,
-                        view_messages=False if view_messages is True else True if view_messages is False else None,
-                        send_messages=False if send_messages is True else True if send_messages is False else None,
-                        send_media=False if send_media is True else True if send_media is False else None,
-                        send_stickers=False if send_stickers is True else True if send_stickers is False else None,
-                        send_gifs=False if send_gifs is True else True if send_gifs is False else None,
-                        send_games=False if send_games is True else True if send_games is False else None,
-                        send_inline=False if send_inline is True else True if send_inline is False else None,
-                        send_polls=False if send_polls is True else True if send_polls is False else None,
-                        change_info=False if change_info is True else True if change_info is False else None,
-                        invite_users=False if invite_users is True else True if invite_users is False else None,
-                        pin_messages=False if pin_messages is True else True if pin_messages is False else None
-                    )
-                ))
-        else:
-            user = await self.get_input_entity(user)
-            if not isinstance(user, types.InputPeerUser):
-                raise ValueError('You must pass a user entity')
 
-            return await self(functions.channels.EditBannedRequest(
-                channel=entity,
-                user_id=user,
-                banned_rights=types.ChatBannedRights(
-                    view_messages=False if view_messages is True else True if view_messages is False else None,
-                    send_messages=False if send_messages is True else True if send_messages is False else None,
-                    send_media=False if send_media is True else True if send_media is False else None,
-                    send_stickers=False if send_stickers is True else True if send_stickers is False else None,
-                    send_gifs=False if send_gifs is True else True if send_gifs is False else None,
-                    send_games=False if send_games is True else True if send_games is False else None,
-                    send_inline=False if send_inline is True else True if send_inline is False else None,
-                    send_polls=False if send_polls is True else True if send_polls is False else None,
-                    change_info=False if change_info is True else True if change_info is False else None,
-                    invite_users=False if invite_users is True else True if invite_users is False else None,
-                    pin_messages=False if pin_messages is True else True if pin_messages is False else None
-                )
+        rights = types.ChatBannedRights(
+            until_date=until_date,
+            view_messages=not view_messages,
+            send_messages=not send_messages,
+            send_media=not send_media,
+            send_stickers=not send_stickers,
+            send_gifs=not send_gifs,
+            send_games=not send_games,
+            send_inline=not send_inline,
+            send_polls=not send_polls,
+            change_info=not change_info,
+            invite_users=not invite_users,
+            pin_messages=not pin_messages
+        )
+
+        if user is None:
+            return await self(functions.messages.EditChatDefaultBannedRightsRequest(
+                peer=entity,
+                banned_rights=rights
             ))
+
+        user = await self.get_input_entity(user)
+        if not isinstance(user, types.InputPeerUser):
+            raise ValueError('You must pass a user entity')
+
+        return await self(functions.channels.EditBannedRequest(
+            channel=entity,
+            user_id=user,
+            banned_rights=rights
+        ))
 
     # endregion

--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -766,6 +766,7 @@ class ChatMethods(UserMethods):
             self: 'TelegramClient',
             entity: 'hints.EntityLike',
             user: 'hints.EntityLike',
+            *,
             change_info: bool = None,
             post_messages: bool = None,
             edit_messages: bool = None,
@@ -776,40 +777,66 @@ class ChatMethods(UserMethods):
             add_admins: bool = None,
             is_admin: bool = None) -> types.Updates:
         """
-        Edits admin permissions for the given entity
-        will raise an error if wrong combination of rights are given
+        Edits admin permissions for someone in a chat.
+
+        Raises an error if wrong a combination of rights are given
+        (e.g. you don't have enough permissions to grant one).
+
+        Unless otherwise stated, permissions will work in channels and megagroups.
+
         Arguments
             entity (`entity`):
-                Either a channel or a supergroup or a chat.
+                The channel, megagroup or chat where the promotion should happen.
+
             user (`entity`):
-                the user to be promoted
+                The user to be promoted.
+
             change_info (`bool`, optional):
-                Whether the user will be able to change info. works in channels and supergroups.
+                Whether the user will be able to change info.
+
             post_messages (`bool`, optional):
-                Whether the user will be able to post in the channel. only works in channels.
+                Whether the user will be able to post in the channel.
+                This will only work in broadcast channels.
+
             edit_messages (`bool`, optional):
-                Whether the user will be able to edit messages in the channel. only works in channels.
+                Whether the user will be able to edit messages in the channel.
+                This will only work in broadcast channels.
+
             delete_messages (`bool`, optional):
-                Whether the user will be able to delete messages. works in channels and supergroups.
+                Whether the user will be able to delete messages.
+
             ban_users (`bool`, optional):
-                Whether the user will be able to ban users. works in channels and supergroups.
+                Whether the user will be able to ban users.
+
             invite_users (`bool`, optional):
                 Whether the user will be able to invite users. Needs some testing.
+
             pin_messages (`bool`, optional):
-                Whether the user will be able to pin messages. works in channels and supergroups.
+                Whether the user will be able to pin messages.
+
             add_admins (`bool`, optional):
-                Whether the user will be able to add admins. works in channels and supergroups.
+                Whether the user will be able to add admins.
+
             is_admin (`bool`, optional):
-                Whether the user will be an admin in the chat. only works in chats.
+                Whether the user will be an admin in the chat.
+                This will only work in small group chats.
+
         Returns
-            returns an Updates object.
+            The resulting :tl:`Updates` object.
+
+        Example
+            .. code-block:: python
+
+                # Allowing `user` to pin messages in `chat`
+                client.edit_admin(chat, user, pin_messages=True)
         """
         entity = await self.get_input_entity(entity)
         user = await self.get_input_entity(user)
         if not isinstance(user, types.InputPeerUser):
-            raise ValueError("You must pass a user entity")
+            raise ValueError('You must pass a user entity')
+
         if isinstance(entity, types.InputPeerChannel):
-            result = await self(functions.channels.EditAdminRequest(
+            return await self(functions.channels.EditAdminRequest(
                 entity,
                 user,
                 types.ChatAdminRights(
@@ -824,16 +851,16 @@ class ChatMethods(UserMethods):
                 )
             ))
         elif isinstance(entity, types.InputPeerChat):
-            result = await self(functions.messages.EditChatAdminRequest(entity, user, is_admin=is_admin))
+            return await self(functions.messages.EditChatAdminRequest(entity, user, is_admin=is_admin))
         else:
-            raise ValueError("You must pass either a channel or a supergroup or a normal group")
-        return result
+            raise ValueError('You must pass either a channel or a supergroup or a normal group')
 
     async def edit_permission(
             self: 'TelegramClient',
             entity: 'hints.EntityLike',
             user: 'typing.Optional[hints.EntityLike]' = None,
             until_date: 'hints.DateLike' = None,
+            *,
             view_messages: bool = None,
             send_messages: bool = None,
             send_media: bool = None,
@@ -846,71 +873,81 @@ class ChatMethods(UserMethods):
             invite_users: bool = None,
             pin_messages: bool = None) -> types.Updates:
         """
-        Edits user permissions or channel/supergroup global permission for the given entity
-        will raise an error if wrong combination of rights are given
+        Edits user restrictions in a chat.
+
+        Raises an error if wrong a combination of rights are given
+        (e.g. you don't have enough permissions to revoke one).
+
         Arguments
             entity (`entity`):
-                Either a channel or a supergroup.
-            user (`entity`,optional):
-                If passed the permission will be changed for the specific user instead of the whole entity.
+                The channel or megagroup where the restriction should happen.
+
+            user (`entity`, optional):
+                If specified, the permission will be changed for the specific user.
+                If left as ``None``, the default chat permissions will be updated.
+
             until_date (`DateLike`, optional):
-                Date when the user will be unbanned, unix time.
-                If user is banned for more than 366 days or less than 30 seconds from the current time they are
-                considered to be banned forever. Defaults to 0 (ban forever).
+                When the user will be unbanned.
+
+                If the due date or duration is longer than 366 days or shorter than
+                30 seconds, the ban will be forever. Defaults to ``0`` (ban forever).
+
             view_messages (`bool`, optional):
-                If this is set to False the user will be banned. only usable when a user entity is passed.
+                Whether the user is able to view messages or not.
+                Forbidding someone from viewing messages equals to banning them.
+                This will only work if ``user`` is set.
+
             send_messages (`bool`, optional):
-                Permission to send messages in the channel/supergroup.
+                Whether the user is able to send messages or not.
+
             send_media (`bool`, optional):
-                Permission to send media files in the channel/supergroup.
+                Whether the user is able to send media or not.
+
             send_stickers (`bool`, optional):
-                Permission to send stickers in the channel/supergroup.
+                Whether the user is able to send stickers or not.
+
             send_gifs (`bool`, optional):
-                Permission to send stickers in the channel/supergroup.
+                Whether the user is able to send animated gifs or not.
+
             send_games (`bool`, optional):
-                Permission to link games in the channel/supergroup.
+                Whether the user is able to send games or not.
+
             send_inline (`bool`, optional):
-                Permission to use inline bots in the channel/supergroup.
+                Whether the user is able to use inline bots or not.
+
             send_polls (`bool`, optional):
-                Permission to send polls in the channel/supergroup.
+                Whether the user is able to send polls or not.
+
             change_info (`bool`, optional):
-                Permission to change channel/supergroup info.
+                Whether the user is able to change info or not.
+
             invite_users (`bool`, optional):
-                Permission to invite users to the channel/supergroup.
+                Whether the user is able to invite other users or not.
+
             pin_messages (`bool`, optional):
-                Permission to pin messages in the channel/supergroup.
+                Whether the user is able to pin messages or not.
+
         Returns
-            returns an Updates object.
+            The resulting :tl:`Updates` object.
+
+        Example
+            .. code-block:: python
+
+                from datetime import timedelta
+
+                # Kicking `user` from `chat` for 1 minute
+                client.edit_permission(chat, user, timedelta(minutes=1),
+                                       view_messages=False)
+
+                # Banning `user` from `chat` forever
+                client.edit_permission(chat, user, view_messages=False)
         """
         entity = await self.get_input_entity(entity)
         if not isinstance(entity,types.InputPeerChannel):
-            raise ValueError("You must pass either a channel or a supergroup")
-        else:
-            if user is None:
-                result = await self(functions.messages.EditChatDefaultBannedRightsRequest(
-                        peer=entity,
-                        banned_rights=types.ChatBannedRights(
-                            until_date=until_date,
-                            view_messages=view_messages,
-                            send_messages=send_messages,
-                            send_media=send_media,
-                            send_stickers=send_stickers,
-                            send_gifs=send_gifs,
-                            send_games=send_games,
-                            send_inline=send_inline,
-                            send_polls=send_polls,
-                            change_info=change_info,
-                            invite_users=invite_users,
-                            pin_messages=pin_messages
-                        )
-                    ))
-            else:
-                user = await self.get_input_entity(user)
-                if not isinstance(user, types.InputPeerUser):
-                    raise ValueError("You must pass a user entity")
-                result = await self(functions.channels.EditBannedRequest(
-                    channel=entity,
-                    user_id=user,
+            raise ValueError('You must pass either a channel or a supergroup')
+        elif user is None:
+            return await self(functions.messages.EditChatDefaultBannedRightsRequest(
+                    peer=entity,
                     banned_rights=types.ChatBannedRights(
                         until_date=until_date,
                         view_messages=view_messages,
@@ -926,5 +963,28 @@ class ChatMethods(UserMethods):
                         pin_messages=pin_messages
                     )
                 ))
-        return result
+        else:
+            user = await self.get_input_entity(user)
+            if not isinstance(user, types.InputPeerUser):
+                raise ValueError('You must pass a user entity')
+
+            return await self(functions.channels.EditBannedRequest(
+                channel=entity,
+                user_id=user,
+                banned_rights=types.ChatBannedRights(
+                    until_date=until_date,
+                    view_messages=view_messages,
+                    send_messages=send_messages,
+                    send_media=send_media,
+                    send_stickers=send_stickers,
+                    send_gifs=send_gifs,
+                    send_games=send_games,
+                    send_inline=send_inline,
+                    send_polls=send_polls,
+                    change_info=change_info,
+                    invite_users=invite_users,
+                    pin_messages=pin_messages
+                )
+            ))
+
     # endregion

--- a/telethon/events/callbackquery.py
+++ b/telethon/events/callbackquery.py
@@ -26,12 +26,8 @@ class CallbackQuery(EventBuilder):
             can use ``re.compile(b'data_')``.
     """
     def __init__(
-            self, chats=None, *, blacklist_chats=False, func=None, data=None, pattern=None):
+            self, chats=None, *, blacklist_chats=False, func=None, data=None):
         super().__init__(chats, blacklist_chats=blacklist_chats, func=func)
-
-        if data is None and pattern is None:
-            self._log.warn("Please don't use both data and pattern.data will be ignored if you do so")
-            data = None
 
         if isinstance(data, bytes):
             self.data = data
@@ -47,19 +43,6 @@ class CallbackQuery(EventBuilder):
             self.data = data.match
         else:
             raise TypeError('Invalid data type given')
-
-        if isinstance(pattern, str):
-            self.pattern = re.compile(pattern).match
-        elif not pattern or callable(pattern):
-            self.pattern = pattern
-        elif hasattr(pattern, 'match') and callable(pattern.match):
-            self.pattern = pattern.match
-        else:
-            raise TypeError('Invalid pattern type given')
-
-        self._no_check = all(x is None for x in (
-            self.chats, self.func, self.data, self.pattern,
-        ))
 
     @classmethod
     def build(cls, update):
@@ -79,9 +62,6 @@ class CallbackQuery(EventBuilder):
 
     def filter(self, event):
         # We can't call super().filter(...) because it ignores chat_instance
-        if self._no_check:
-            return event
-
         if self.chats is not None:
             inside = event.query.chat_instance in self.chats
             if event.chat_id:
@@ -97,12 +77,6 @@ class CallbackQuery(EventBuilder):
                     return None
             elif event.query.data != self.data:
                 return None
-
-        if self.pattern:
-            match = self.pattern(event.message.message or '')
-            if not match:
-                return
-            event.pattern_match = match
 
         if not self.func or self.func(event):
             return event


### PR DESCRIPTION
Both these methods should work regardless of the entity type(group or channel).
If no user is passed to the edit_permission method the group permission will be the one affected. 