### PR TITLE
Check exist flush method

### DIFF
--- a/telethon/client/downloads.py
+++ b/telethon/client/downloads.py
@@ -439,7 +439,8 @@ class DownloadMethods:
                     if inspect.isawaitable(r):
                         await r
 
-            if hasattr(f, 'flush') and callable(getattr(f, 'flush')):
+            # Not all IO objects have flush (see #1227)
+            if callable(getattr(f, 'flush', None)):
                 f.flush()
 
             if in_memory:

--- a/telethon/client/downloads.py
+++ b/telethon/client/downloads.py
@@ -439,7 +439,9 @@ class DownloadMethods:
                     if inspect.isawaitable(r):
                         await r
 
-            f.flush()
+            if hasattr(f, 'flush') and callable(getattr(f, 'flush')):
+                f.flush()
+
             if in_memory:
                 return f.getvalue()
         finally:


### PR DESCRIPTION
For example, GrinIn (MongoPy) don't have flush() method.
On previous version of Telethon flush() not used.