### PR TITLE
Fix kick_participant in channels

### DIFF
--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -1085,18 +1085,19 @@ class ChatMethods:
             if isinstance(user, types.InputPeerSelf):
                 await self(functions.channels.LeaveChannelRequest(entity))
             else:
-                await self([
+                await self(
                     functions.channels.EditBannedRequest(
                         channel=entity,
                         user_id=user,
                         banned_rights=types.ChatBannedRights(until_date=None, view_messages=True)
-                    ),
+                    ))
+                await asyncio.sleep(0.1)
+                await self(
                     functions.channels.EditBannedRequest(
                         channel=entity,
                         user_id=user,
                         banned_rights=types.ChatBannedRights(until_date=None)
-                    ),
-                ], ordered=True)
+                    ))
         else:
             raise ValueError('You must pass either a channel or a chat')
 

--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -1085,19 +1085,17 @@ class ChatMethods:
             if isinstance(user, types.InputPeerSelf):
                 await self(functions.channels.LeaveChannelRequest(entity))
             else:
-                await self(
-                    functions.channels.EditBannedRequest(
-                        channel=entity,
-                        user_id=user,
-                        banned_rights=types.ChatBannedRights(until_date=None, view_messages=True)
-                    ))
+                await self(functions.channels.EditBannedRequest(
+                    channel=entity,
+                    user_id=user,
+                    banned_rights=types.ChatBannedRights(until_date=None, view_messages=True)
+                ))
                 await asyncio.sleep(0.5)
-                await self(
-                    functions.channels.EditBannedRequest(
-                        channel=entity,
-                        user_id=user,
-                        banned_rights=types.ChatBannedRights(until_date=None)
-                    ))
+                await self(functions.channels.EditBannedRequest(
+                    channel=entity,
+                    user_id=user,
+                    banned_rights=types.ChatBannedRights(until_date=None)
+                ))
         else:
             raise ValueError('You must pass either a channel or a chat')
 

--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -1091,7 +1091,7 @@ class ChatMethods:
                         user_id=user,
                         banned_rights=types.ChatBannedRights(until_date=None, view_messages=True)
                     ))
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0.5)
                 await self(
                     functions.channels.EditBannedRequest(
                         channel=entity,


### PR DESCRIPTION
Previously it was banning users, presumably due to a server side change. Sleeping for 0 doesn't work but sleeping for 0.1 does, so it will do.