### PR TITLE
Remove check for InputPeerSelf in edit_admin

### DIFF
--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -864,8 +864,6 @@ class ChatMethods:
         """
         entity = await self.get_input_entity(entity)
         user = await self.get_input_entity(user)
-        if isinstance(user, types.InputPeerSelf):
-            raise ValueError('You cannot admin yourself')
 
         if not isinstance(user, types.InputPeerUser):
             raise ValueError('You must pass a user entity')

--- a/telethon/client/chats.py
+++ b/telethon/client/chats.py
@@ -864,8 +864,7 @@ class ChatMethods:
         """
         entity = await self.get_input_entity(entity)
         user = await self.get_input_entity(user)
-
-        if not isinstance(user, types.InputPeerUser):
+        if not isinstance(user, (types.InputPeerUser, types.InputPeerSelf)):
             raise ValueError('You must pass a user entity')
 
         perm_names = (


### PR DESCRIPTION
To allow changing your own admin title in groups you own.