### PR TITLE
Use channels.GetFullChannel instead of messages.getPeerDialogs

### DIFF
--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -459,7 +459,7 @@ class UpdateMethods:
 
             if not pts_date:
                 # First-time, can't get difference. Get pts instead.
-                result = await self(functions.channels.getFullChannel(
+                result = await self(functions.channels.GetFullChannelRequest(
                     channel=where
                 ))
                 self._state_cache[channel_id] = result.full_chat.pts

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -460,7 +460,7 @@ class UpdateMethods:
             if not pts_date:
                 # First-time, can't get difference. Get pts instead.
                 result = await self(functions.channels.GetFullChannelRequest(
-                    channel=where
+                    utils.get_input_channel(where)
                 ))
                 self._state_cache[channel_id] = result.full_chat.pts
                 return

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -459,10 +459,10 @@ class UpdateMethods:
 
             if not pts_date:
                 # First-time, can't get difference. Get pts instead.
-                result = await self(functions.messages.GetPeerDialogsRequest([
-                    utils.get_input_dialog(where)
-                ]))
-                self._state_cache[channel_id] = result.dialogs[0].pts
+                result = await self(functions.channels.getFullChannel(
+                    channel=where
+                ))
+                self._state_cache[channel_id] = result.full_chat.pts
                 return
 
             result = await self(functions.updates.GetChannelDifferenceRequest(


### PR DESCRIPTION
Bots can't use messages.getPeerDialogs, so the only way to get the initial channel pts for them is to use getFullChannel.