### PR TITLE
Fix MessageButton.click() with weird strings

### DIFF
--- a/telethon/tl/custom/messagebutton.py
+++ b/telethon/tl/custom/messagebutton.py
@@ -78,7 +78,7 @@ class MessageButton:
         """
         if isinstance(self.button, types.KeyboardButton):
             return await self._client.send_message(
-                self._chat, self.button.text, reply_to=self._msg_id)
+                self._chat, self.button.text, reply_to=self._msg_id, parse_mode=None)
         elif isinstance(self.button, types.KeyboardButtonCallback):
             req = functions.messages.GetBotCallbackAnswerRequest(
                 peer=self._chat, msg_id=self._msg_id, data=self.button.data


### PR DESCRIPTION
The HTML entities were getting parsed according to client parse_mode, leading to empty messages and weird entities