### PR TITLE
Make RPCError subclasses unpicklable again

### DIFF
--- a/tests/telethon/test_pickle.py
+++ b/tests/telethon/test_pickle.py
@@ -1,0 +1,35 @@
+import pickle
+
+from telethon.errors import RPCError, BadRequestError, FileIdInvalidError, NetworkMigrateError
+
+
+def _assert_equality(error, unpickled_error):
+    assert error.code == unpickled_error.code
+    assert error.message == unpickled_error.message
+    assert type(error) == type(unpickled_error)
+    assert str(error) == str(unpickled_error)
+
+
+def test_base_rpcerror_pickle():
+    error = RPCError("request", "message", 123)
+    unpickled_error = pickle.loads(pickle.dumps(error))
+    _assert_equality(error, unpickled_error)
+
+
+def test_rpcerror_pickle():
+    error = BadRequestError("request", "BAD_REQUEST", 400)
+    unpickled_error = pickle.loads(pickle.dumps(error))
+    _assert_equality(error, unpickled_error)
+
+
+def test_fancy_rpcerror_pickle():
+    error = FileIdInvalidError("request")
+    unpickled_error = pickle.loads(pickle.dumps(error))
+    _assert_equality(error, unpickled_error)
+
+
+def test_fancy_rpcerror_capture_pickle():
+    error = NetworkMigrateError(request="request", capture=5)
+    unpickled_error = pickle.loads(pickle.dumps(error))
+    _assert_equality(error, unpickled_error)
+    assert error.new_dc == unpickled_error.new_dc


### PR DESCRIPTION
The problem is that custom RPCError classes have custom `__init__`s that aren't compatible with the parent. This pull request adds a `__reduce__` for all custom RPCErrors to make them (un)picklable. Might be more optimal to make new base classes or edit the base classes to somehow detect that it's one of the generated RPCErrors, but this works too.

Fixes #749 