### PR TITLE
Fix macOS version parsing if dot number is missing

### DIFF
--- a/telethon/crypto/libssl.py
+++ b/telethon/crypto/libssl.py
@@ -23,7 +23,7 @@ def _find_ssl_lib():
     # https://www.shh.sh/2020/01/04/python-abort-trap-6.html
     if sys.platform == 'darwin':
         release, _version_info, _machine = platform.mac_ver()
-        major = release.split('.', maxsplit=1)[0]
+        ten, major, *minor = release.split('.')
         # macOS 10.14 "mojave" is the last known major release
         # to support unversioned libssl.dylib. Anything above
         # needs specific versions

--- a/telethon/version.py
+++ b/telethon/version.py
@@ -1,3 +1,3 @@
 # Versions should comply with PEP440.
 # This line is parsed in setup.py:
-__version__ = '1.11.1'
+__version__ = '1.11.2'


### PR DESCRIPTION
Hi, this is a regression fix for 8aa15174ab0290c0ad36523147db5fde82f8da4c which breaks macOS again.
As mentioned in the original PR discussion (https://github.com/LonamiWebs/Telethon/pull/1369#issuecomment-589660260), the present code grabs the wrong part of the version number (10 instead of 15, out of '10.15').

I've changed the code slightly to extract the first two numbers and optionally allow dot releases (10.15.4).