### PR TITLE
Fixed a problem with proxy connection: [Errno 115] Operation now in progress

### DIFF
--- a/telethon/network/connection/connection.py
+++ b/telethon/network/connection/connection.py
@@ -65,7 +65,7 @@ class Connection(abc.ABC):
             else:
                 s.set_proxy(*self._proxy)
 
-            s.setblocking(False)
+            s.settimeout(timeout)
             await asyncio.wait_for(
                 self._loop.sock_connect(s, address),
                 timeout=timeout,
@@ -78,14 +78,14 @@ class Connection(abc.ABC):
                         'without the SSL module being available'
                     )
 
-                s.settimeout(timeout)
                 s = ssl_mod.wrap_socket(
                     s,
                     do_handshake_on_connect=True,
                     ssl_version=ssl_mod.PROTOCOL_SSLv23,
                     ciphers='ADH-AES256-SHA'
                 )
-                s.setblocking(False)
+                
+            s.setblocking(False)
 
             self._reader, self._writer = \
                 await asyncio.open_connection(sock=s, loop=self._loop)


### PR DESCRIPTION
# Setup

A simple script:
```python
from telethon.sync import TelegramClient
import socks
import logging
logging.basicConfig(level=logging.DEBUG)

api_id = 11111
api_hash = '...'
proxy=(socks.SOCKS4, '127.0.0.1', 9050)

with TelegramClient('anon', api_id, api_hash, proxy=proxy, timeout=60) as client:
	print(client.get_me().stringify())
```

The socks proxy is Tor, so it is quite slow.

# Expected behavior

The script connect to telegram through the proxy and prints user info.

# Actual behavior

The script fails to connect to the proxy. Log:
```
DEBUG:asyncio:Using selector: EpollSelector
INFO:telethon.network.mtprotosender:Connecting to 149.154.167.51:443/TcpFull...
DEBUG:telethon.network.mtprotosender:Connection attempt 1...
WARNING:telethon.network.mtprotosender:Attempt 1 at connecting failed: ProxyConnectionError: Error connecting to SOCKS4 proxy 127.0.0.1:9050: [Errno 115] Operation now in progress
DEBUG:telethon.network.mtprotosender:Connection attempt 2...
WARNING:telethon.network.mtprotosender:Attempt 2 at connecting failed: ProxyConnectionError: Error connecting to SOCKS4 proxy 127.0.0.1:9050: [Errno 115] Operation now in progress
...
```

# The problem
 
According to [python docs](https://docs.python.org/3/library/socket.html#timeouts-and-the-connect-method):
> The connect() operation is also subject to the timeout setting, and in general it is recommended to call settimeout() before calling connect() or pass a timeout parameter to create_connection(). However, the system network stack may also return a connection timeout error of its own regardless of any Python socket timeout setting.

The error description for code 115 says:
> EINPROGRESS
> The socket is nonblocking and the connection cannot be completed 
immediately. It is possible to select(2) or poll(2) for completion by
selecting the socket for writing. After select(2) indicates
writability, use getsockopt(2) to read the SO_ERROR option at level
SOL_SOCKET to determine whether connect() completed successfully
(SO_ERROR is zero) or unsuccessfully (SO_ERROR is one of the usual
error codes listed here, explaining the reason for the failure).

It seems that the tcp handshake with proxy is not being finished with time.

# The solution

I've changed `setblocking` to `settimeout` and it worked great for me.