### PR TITLE
fix C language header

### DIFF
--- a/readthedocs/developing/telegram-api-in-other-languages.rst
+++ b/readthedocs/developing/telegram-api-in-other-languages.rst
@@ -10,7 +10,7 @@ understand the official Telegram documentation) on several languages
 (even more Python too), listed below:
 
 C
-*
+=
 
 Possibly the most well-known unofficial open source implementation out
 there by `@vysheng <https://github.com/vysheng>`__,

--- a/readthedocs/developing/telegram-api-in-other-languages.rst
+++ b/readthedocs/developing/telegram-api-in-other-languages.rst
@@ -31,6 +31,9 @@ JavaScript
 
 `Ali Gasymov <https://github.com/alik0211>`__ made the `@mtproto/core <https://github.com/alik0211/mtproto-core>`__ library for the browser and nodejs installable via `npm <https://www.npmjs.com/package/@mtproto/core>`__.
 
+`painor <https://github.com/painor>`__ is the primary author of `gramjs <https://github.com/gram-js/gramjs>`__,
+a Telegram client implementation in JavaScript.
+
 Kotlin
 ======
 


### PR DESCRIPTION
The current documentation left-bar shows all languages being a subtree of C language. This tiny commit fixes that issue.

Problematic:
![Screen Shot 2020-04-29 at 15 07 46](https://user-images.githubusercontent.com/19636264/80599425-31166700-8a2b-11ea-8182-3276b5ab0629.png)
