### PR TITLE
Fix SendMessage FloodWaits on TEST cloud

### DIFF
--- a/telethon/client/users.py
+++ b/telethon/client/users.py
@@ -92,6 +92,9 @@ class UserMethods:
                 self._flood_waited_requests\
                     [request.CONSTRUCTOR_ID] = time.time() + e.seconds
 
+                if e.seconds == 0:
+                    e.seconds = 1
+
                 if e.seconds <= self.flood_sleep_threshold:
                     self._log[__name__].info(*_fmt_flood(e.seconds, request))
                     await asyncio.sleep(e.seconds, loop=self._loop)

--- a/telethon/client/users.py
+++ b/telethon/client/users.py
@@ -92,6 +92,8 @@ class UserMethods:
                 self._flood_waited_requests\
                     [request.CONSTRUCTOR_ID] = time.time() + e.seconds
 
+                # In test servers, FLOOD_WAIT_0 has been observed, and sleeping for
+                # such a short amount will cause retries very fast leading to issues.
                 if e.seconds == 0:
                     e.seconds = 1
 


### PR DESCRIPTION
On the TEST cloud, flood waits do not always include the correct number of seconds. The server sends FLOOD_WAIT_0, so Telethon sleeps 0 seconds before retrying. This leads to a ValueError: Request was unsuccessful 6 times. By making a minimum flood wait duration of 1 second, this error is mitigated, as the delay is long enough to avoid the rapid retries, and the request succeeds on the 2nd attempt. For once, I tested this change, and it fixed the issue.