### PR TITLE
IPv6 fix

### DIFF
--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -18,7 +18,7 @@ from ..tl.alltlobjects import LAYER
 
 DEFAULT_DC_ID = 2
 DEFAULT_IPV4_IP = '149.154.167.51'
-DEFAULT_IPV6_IP = '[2001:67c:4e8:f002::a]'
+DEFAULT_IPV6_IP = '2001:67c:4e8:f002::a'
 DEFAULT_PORT = 443
 
 if typing.TYPE_CHECKING:


### PR DESCRIPTION
Hello.
By default, if `use_ipv6` set to `True`, telethon connects to `[2001:67c:4e8:f002::a]`, although it fail to reach telegram servers: [example](https://gist.github.com/conetra/9c01ebbb469465f30135ca3574894260) | [output](http://ix.io/2tyI).
But if we remove brackets, everything goes fine: [example](https://gist.github.com/conetra/de3e13bb6b54e1ef1788725f8774cfbf) | [output](http://ix.io/2tyH).

I'm unsure if that applies even for native IPv6 setups, but this fix required for proxies.