### PR TITLE
Added extracting metadata from audio/video files with byte array/stream types

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -805,8 +805,9 @@ def is_gif(file):
 
 def is_audio(file):
     """Returns `True` if the file has an audio mime type."""
-    filename = 'a' + _get_extension(file)
-    if filename == 'a':
+    ext = _get_extension(file)
+    filename = 'a' + ext
+    if not ext:
         metadata = _get_metadata(file)
         if metadata and metadata.has('mime_type'):
             return metadata.get('mime_type').startswith('audio/')
@@ -818,8 +819,9 @@ def is_audio(file):
 
 def is_video(file):
     """Returns `True` if the file has a video mime type."""
-    filename = 'a' + _get_extension(file)
-    if filename == 'a':
+    ext = _get_extension(file)
+    filename = 'a' + ext
+    if not ext:
         metadata = _get_metadata(file)
         if metadata and metadata.has('mime_type'):
             return metadata.get('mime_type').startswith('video/')

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -815,9 +815,16 @@ def is_audio(file):
 
 
 def is_video(file):
-    """Returns `True` if the file extension looks like a video file."""
-    file = 'a' + _get_extension(file)
-    return (mimetypes.guess_type(file)[0] or '').startswith('video/')
+    """Returns `True` if the file has a video mime type."""
+    filename = 'a' + _get_extension(file)
+    if filename == 'a':
+        metadata = _get_metadata(file)
+        if metadata and metadata.has('mime_type'):
+            return metadata.get('mime_type').startswith('video/')
+        else:
+            return False
+    else:
+        return (mimetypes.guess_type(filename)[0] or '').startswith('video/')
 
 
 def is_list_like(obj):

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -607,6 +607,8 @@ def _get_metadata(file):
         try:
             file = io.BytesIO(file) if isinstance(file, bytes) else file
             parser = hachoir.parser.createParser(file)
+            if isinstance(file, str):
+                parser.close()
             return hachoir.metadata.extractMetadata(parser)
         except Exception as e:
             _log.warning('Failed to analyze %s: %s %s', file, e.__class__, e)

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -610,6 +610,10 @@ def _get_metadata(file):
             if isinstance(file, str):
                 parser.close()
             return hachoir.metadata.extractMetadata(parser)
+        except AssertionError:
+            msg = ('Your version of Hachoir can only open in-disk files.'
+                   'Update it to read byte arrays/streams.')
+            _log.warning('Failed to analyze %s: %s', file, msg)
         except Exception as e:
             _log.warning('Failed to analyze %s: %s %s', file, e.__class__, e)
 
@@ -806,7 +810,6 @@ def is_gif(file):
 def is_audio(file):
     """Returns `True` if the file has an audio mime type."""
     ext = _get_extension(file)
-    filename = 'a' + ext
     if not ext:
         metadata = _get_metadata(file)
         if metadata and metadata.has('mime_type'):
@@ -814,13 +817,13 @@ def is_audio(file):
         else:
             return False
     else:
-        return (mimetypes.guess_type(filename)[0] or '').startswith('audio/')
+        file = 'a' + ext
+        return (mimetypes.guess_type(file)[0] or '').startswith('audio/')
 
 
 def is_video(file):
     """Returns `True` if the file has a video mime type."""
     ext = _get_extension(file)
-    filename = 'a' + ext
     if not ext:
         metadata = _get_metadata(file)
         if metadata and metadata.has('mime_type'):
@@ -828,7 +831,8 @@ def is_video(file):
         else:
             return False
     else:
-        return (mimetypes.guess_type(filename)[0] or '').startswith('video/')
+        file = 'a' + ext
+        return (mimetypes.guess_type(file)[0] or '').startswith('video/')
 
 
 def is_list_like(obj):

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -611,6 +611,7 @@ def _get_metadata(file):
     # The parser may fail and we don't want to crash if
     # the extraction process fails.
     try:
+        # Note: aiofiles are intentionally left out for simplicity
         if isinstance(file, str):
             stream = open(file, 'rb')
         elif isinstance(file, bytes):
@@ -624,22 +625,18 @@ def _get_metadata(file):
                 seekable = False
 
         if not seekable:
-            _log.warning(
-                'Could not read metadata since the file is not '
-                'seekable so the entire file will be read in-memory')
-
-            data = file.read()
-            stream = io.BytesIO(data)
-            close_stream = True
+            return None
 
         pos = stream.tell()
         filename = getattr(file, 'name', '')
+
         parser = hachoir.parser.guess.guessParser(hachoir.stream.InputIOStream(
             stream,
             source='file:' + filename,
             tags=[],
             filename=filename
         ))
+
         return hachoir.metadata.extractMetadata(parser)
 
     except Exception as e:


### PR DESCRIPTION
Hachoir [now supports](https://github.com/vstinner/hachoir/pull/55) creating parsers from byte streams. So we're able to extract metadata from audio/video files that are byte arrays/streams. This fixes the issue where >10MB songs that were byte arrays/streams were sent as files. I'm not sure about videos but since `is_video` returned *False* for byte arrays/streams before, I guess they were sent as files too.
The downside of the solution is that byte arrays/streams have their metadata extracted (using `_get_metadata`) twice: once in `is_audio`/`is_video`, and if one of the two is *True*, then once again inside the condition.

Any feedback you can give me on this would be much appreciated.