### PR TITLE
Add parameter to pass raw entities when sending message

### DIFF
--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -725,7 +725,7 @@ class MessageMethods:
                     silent=silent,
                     reply_to=reply_to,
                     buttons=markup,
-                    entities=message.entities,
+                    formatting_entities=message.entities,
                     schedule=schedule
                 )
 

--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -551,6 +551,7 @@ class MessageMethods:
             *,
             reply_to: 'typing.Union[int, types.Message]' = None,
             parse_mode: typing.Optional[str] = (),
+            formatting_entities: typing.Optional[typing.List[types.TypeMessageEntity]] = None,
             link_preview: bool = True,
             file: 'typing.Union[hints.FileLike, typing.Sequence[hints.FileLike]]' = None,
             force_document: bool = False,
@@ -597,6 +598,9 @@ class MessageMethods:
                 <telethon.client.messageparse.MessageParseMethods.parse_mode>`
                 property for allowed values. Markdown parsing will be used by
                 default.
+
+            formatting_entities (`list`, optional):
+                A list of message formatting entities. When provided, the ``parse_mode`` is ignored.
 
             link_preview (`bool`, optional):
                 Should the link preview be shown?
@@ -699,7 +703,7 @@ class MessageMethods:
                 entity, file, caption=message, reply_to=reply_to,
                 parse_mode=parse_mode, force_document=force_document,
                 buttons=buttons, clear_draft=clear_draft, silent=silent,
-                schedule=schedule
+                schedule=schedule, entities=formatting_entities
             )
 
         entity = await self.get_input_entity(entity)
@@ -739,7 +743,8 @@ class MessageMethods:
             )
             message = message.message
         else:
-            message, msg_ent = await self._parse_message_text(message, parse_mode)
+            if formatting_entities is None:
+                message, formatting_entities = await self._parse_message_text(message, parse_mode)
             if not message:
                 raise ValueError(
                     'The message cannot be empty unless a file is provided'
@@ -748,7 +753,7 @@ class MessageMethods:
             request = functions.messages.SendMessageRequest(
                 peer=entity,
                 message=message,
-                entities=msg_ent,
+                entities=formatting_entities,
                 no_webpage=not link_preview,
                 reply_to_msg_id=utils.get_message_id(reply_to),
                 clear_draft=clear_draft,
@@ -900,6 +905,7 @@ class MessageMethods:
             text: str = None,
             *,
             parse_mode: str = (),
+            formatting_entities: typing.Optional[typing.List[types.TypeMessageEntity]] = None,
             link_preview: bool = True,
             file: 'hints.FileLike' = None,
             force_document: bool = False,
@@ -938,6 +944,9 @@ class MessageMethods:
                 <telethon.client.messageparse.MessageParseMethods.parse_mode>`
                 property for allowed values. Markdown parsing will be used by
                 default.
+
+            formatting_entities (`list`, optional):
+                A list of message formatting entities. When provided, the ``parse_mode`` is ignored.
 
             link_preview (`bool`, optional):
                 Should the link preview be shown?
@@ -999,7 +1008,8 @@ class MessageMethods:
             message = entity
             entity = entity.peer_id
 
-        text, msg_entities = await self._parse_message_text(text, parse_mode)
+        if formatting_entities is None:
+            text, formatting_entities = await self._parse_message_text(text, parse_mode)
         file_handle, media, image = await self._file_to_media(file,
                 force_document=force_document)
 
@@ -1008,7 +1018,7 @@ class MessageMethods:
                 id=entity,
                 message=text,
                 no_webpage=not link_preview,
-                entities=msg_entities,
+                entities=formatting_entities,
                 media=media,
                 reply_markup=self.build_reply_markup(buttons)
             )
@@ -1030,7 +1040,7 @@ class MessageMethods:
             id=utils.get_message_id(message),
             message=text,
             no_webpage=not link_preview,
-            entities=msg_entities,
+            entities=formatting_entities,
             media=media,
             reply_markup=self.build_reply_markup(buttons),
             schedule_date=schedule

--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -703,7 +703,7 @@ class MessageMethods:
                 entity, file, caption=message, reply_to=reply_to,
                 parse_mode=parse_mode, force_document=force_document,
                 buttons=buttons, clear_draft=clear_draft, silent=silent,
-                schedule=schedule, entities=formatting_entities
+                schedule=schedule, formatting_entities=formatting_entities
             )
 
         entity = await self.get_input_entity(entity)

--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -359,12 +359,8 @@ class UploadMethods:
         entity = await self.get_input_entity(entity)
         reply_to = utils.get_message_id(reply_to)
 
-        # Not document since it's subject to change.
-        # Needed when a Message is passed to send_message and it has media.
         if formatting_entities is not None:
             msg_entities = formatting_entities
-        elif 'entities' in kwargs:
-            msg_entities = kwargs['entities']
         else:
             caption, msg_entities =\
                 await self._parse_message_text(caption, parse_mode)

--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -102,6 +102,7 @@ class UploadMethods:
             thumb: 'hints.FileLike' = None,
             allow_cache: bool = True,
             parse_mode: str = (),
+            formatting_entities: typing.Optional[typing.List[types.TypeMessageEntity]] = None,
             voice_note: bool = False,
             video_note: bool = False,
             buttons: 'hints.MarkupLike' = None,
@@ -214,6 +215,9 @@ class UploadMethods:
                 <telethon.client.messageparse.MessageParseMethods.parse_mode>`
                 property for allowed values. Markdown parsing will be used by
                 default.
+
+            formatting_entities (`list`, optional):
+                A list of message formatting entities. When provided, the ``parse_mode`` is ignored.
 
             voice_note (`bool`, optional):
                 If `True` the audio will be sent as a voice note.
@@ -357,7 +361,9 @@ class UploadMethods:
 
         # Not document since it's subject to change.
         # Needed when a Message is passed to send_message and it has media.
-        if 'entities' in kwargs:
+        if formatting_entities is not None:
+            msg_entities = formatting_entities
+        elif 'entities' in kwargs:
             msg_entities = kwargs['entities']
         else:
             caption, msg_entities =\


### PR DESCRIPTION
This pull request adds a parameter for `send_message`, `edit_message` and `send_file` to set custom entities instead of using a text `parse_mode`. While the parse mode can be set to a function, it's a fairly hacky and not type-hinting-friendly solution to pass a non-text `text` and a custom `parse_mode`.

The parameter is named `formatting_entities` instead of `entities` to avoid confusion with the message target `entity`.