### PR TITLE
examples/payment.py - change from_id to sender_id

### DIFF
--- a/telethon/tl/custom/button.py
+++ b/telethon/tl/custom/button.py
@@ -54,7 +54,7 @@ class Button:
         ))
 
     @staticmethod
-    def inline(text, data=None):
+    def inline(text, data=None, requires_password=False):
         """
         Creates a new inline button with some payload data in it.
 
@@ -72,7 +72,7 @@ class Button:
         if len(data) > 64:
             raise ValueError('Too many bytes for the data')
 
-        return types.KeyboardButtonCallback(text, data)
+        return types.KeyboardButtonCallback(text, data, requires_password)
 
     @staticmethod
     def switch_inline(text, query='', same_peer=False):

--- a/telethon_examples/payment.py
+++ b/telethon_examples/payment.py
@@ -85,9 +85,9 @@ async def payment_received_handler(event):
         payment: types.MessageActionPaymentSentMe = event.message.action
         # do something after payment was recieved
         if payment.payload.decode('UTF-8') == 'product A':
-            await bot.send_message(event.message.from_id, 'Thank you for buying product A!')
+            await bot.send_message(event.message.sender_id, 'Thank you for buying product A!')
         elif payment.payload.decode('UTF-8') == 'product B':
-            await bot.send_message(event.message.from_id, 'Thank you for buying product B!')
+            await bot.send_message(event.message.sender_id, 'Thank you for buying product B!')
         raise events.StopPropagation
 
 


### PR DESCRIPTION
+  KeyboardButtonCallback now has bool flag requires_password, so I guess it shall be added to Button.inline
(Idk how to use GH, so both commits got here, sorry)