### PR TITLE
Add support for local_ip address binding

### DIFF
--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -110,6 +110,11 @@ class TelegramBaseClient(abc.ABC):
             function parameters for PySocks, like ``(type, 'hostname', port)``.
             See https://github.com/Anorov/PySocks#usage-1 for more.
 
+        local_addr (`str`, optional):
+            Local host address used to bind the socket to locally.
+            You only need to use this if you have multiple network cards and
+            want to use a specific one.
+
         timeout (`int` | `float`, optional):
             The timeout in seconds to be used when connecting.
             This is **not** the timeout to be used when ``await``'ing for


### PR DESCRIPTION
In order to select the local ip address (both v4 and v6 tested without proxy) I made the following changes. It's especially usefull if you have several ips available on your system and need to be able to select a specific one.

- I've already tested it successfully with `ConnectionTcpAbridged`, `ConnectionTcpFull`, `ConnectionTcpIntermediate` and `ConnectionTcpObfuscated` for both ipv4 and ipv6
- `ConnectionHttp` didn't work at all for me, even before applying the change (Our company firewall might block it, don't know).
- I was not be able to test `ConnectionTcpMTProxy*`, because I had no such proxy available

The part `s.bind((self._local_addr, None))` for general ip binding on the proxied socket is also not tested because i don't have a running proxy available.
