### PR TITLE
Fix: get_me() inside didn't check for connection / RPC errors

### DIFF
--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -439,15 +439,6 @@ class TelegramBaseClient(abc.ABC):
         # A place to store if channels are a megagroup or not (see `edit_admin`)
         self._megagroup_cache = {}
 
-    
-    def __del__(self):
-
-        # Use destructor as the last-resort measure against
-        # unretrieved exceptions in the _sender.disconnected future
-
-        if self.disconnected:
-            self.disconnected.exception()
-
     # endregion
 
     # region Properties

--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -439,6 +439,15 @@ class TelegramBaseClient(abc.ABC):
         # A place to store if channels are a megagroup or not (see `edit_admin`)
         self._megagroup_cache = {}
 
+    
+    def __del__(self):
+
+        # Use destructor as the last-resort measure against
+        # unretrieved exceptions in the _sender.disconnected future
+
+        if self.disconnected:
+            self.disconnected.exception()
+
     # endregion
 
     # region Properties

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -407,7 +407,7 @@ class UpdateMethods:
             # fine, we will just retry next time anyway.
             try:
                 await self.get_me(input_peer=True)
-            except (OSError, errors.RPCError):
+            except OSError:
                 pass
 
         built = EventBuilderDict(self, update, others)

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -405,7 +405,10 @@ class UpdateMethods:
             #
             # It will return `None` if we haven't logged in yet which is
             # fine, we will just retry next time anyway.
-            await self.get_me(input_peer=True)
+            try:
+                await self.get_me(input_peer=True)
+            except (OSError, errors.RPCError):
+                pass
 
         built = EventBuilderDict(self, update, others)
         for conv_set in self._conversations.values():


### PR DESCRIPTION
The call to `get_me()` inside the `_dispatch_update()` was not checked for connection and/or RPC error.
This could lead to unhandled exception inside `_dispatch_update()`, which in turn could lead to unretrievable exception in the future of `_dispatch_update()` and thus, could lead to asyncio warning as in #1589.