### PR TITLE
Actually exclude tests from setup.py installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ def main(argv):
             ],
             keywords='telegram api chat client library messaging mtproto',
             packages=find_packages(exclude=[
-                'telethon_*', 'tests'
+                'telethon_*', 'tests*'
             ]),
             install_requires=['pyaes', 'rsa'],
             extras_require={


### PR DESCRIPTION
Without the glob, the tests module is still installed using `setup.py install`.

Fixes 4ce2c00, see also #1605 