### PR TITLE
Fix UserWarning when forwarding album

### DIFF
--- a/telethon/events/album.py
+++ b/telethon/events/album.py
@@ -260,7 +260,6 @@ class Album(EventBuilder):
             """
             if self._client:
                 kwargs['messages'] = self.messages
-                kwargs['as_album'] = True
                 kwargs['from_peer'] = await self.get_input_chat()
                 return await self._client.forward_messages(*args, **kwargs)
 


### PR DESCRIPTION
When i try to forward album:
```python
@client.on(events.Album)
    async def album_handler(event):
        await event.forward_to(target_username)
```

I have warning:
```
telethon/client/messages.py:894: UserWarning: the as_album argument is deprecated and no longer has any effect
```

So i delete usage of `as_album` kwarg because it deprecated