### PR TITLE
Add `set_proxy()` method to change proxy, without reestablishing client.

### DIFF
--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -600,10 +600,10 @@ class TelegramBaseClient(abc.ABC):
         connection = getattr(self._sender, "_connection", None)
         if connection:
             if isinstance(connection, TcpMTProxy):
-                setattr(connection, "_ip", proxy[0])
-                setattr(connection, "_port", proxy[1])
+                connection._ip = proxy[0]
+                connection._port = proxy[1]
             else:
-                setattr(connection, "_proxy", proxy)
+                connection._proxy = proxy
 
     async def _disconnect_coro(self: 'TelegramClient'):
         await self._disconnect()

--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -364,7 +364,7 @@ class TelegramBaseClient(abc.ABC):
             lang_code=lang_code,
             system_lang_code=system_lang_code,
             lang_pack='',  # "langPacks are for official apps only"
-            query=functions.help.GetConfigRequest(),
+            query=None,
             proxy=init_proxy
         )
 
@@ -525,6 +525,8 @@ class TelegramBaseClient(abc.ABC):
 
         self.session.auth_key = self._sender.auth_key
         self.session.save()
+
+        self._init_request.query = functions.help.GetConfigRequest()
 
         await self._sender.send(functions.InvokeWithLayerRequest(
             LAYER, self._init_request
@@ -715,9 +717,8 @@ class TelegramBaseClient(abc.ABC):
         ))
         self._log[__name__].info('Exporting auth for new borrowed sender in %s', dc)
         auth = await self(functions.auth.ExportAuthorizationRequest(dc_id))
-        req = self._init_with(functions.auth.ImportAuthorizationRequest(
-            id=auth.id, bytes=auth.bytes
-        ))
+        self._init_request.query = functions.auth.ImportAuthorizationRequest(id=auth.id, bytes=auth.bytes)
+        req = functions.InvokeWithLayerRequest(LAYER, self._init_request)
         await sender.send(req)
         return sender
 


### PR DESCRIPTION
Current client implementation does not allow to change proxy without recreating whole `TelegramClient` object.

Instead of creating a new `TelegramClient` each time user needs to change proxy, he can use this method instead.

Pros:
* No need to reopen `Session`
* No cached entities and states are lost
