### PR TITLE
Fix crypto imports on macOS Big Sur

### DIFF
--- a/telethon/crypto/libssl.py
+++ b/telethon/crypto/libssl.py
@@ -23,11 +23,11 @@ def _find_ssl_lib():
     # https://www.shh.sh/2020/01/04/python-abort-trap-6.html
     if sys.platform == 'darwin':
         release, _version_info, _machine = platform.mac_ver()
-        ten, major, *minor = release.split('.')
+        ver, major, *_ = release.split('.')
         # macOS 10.14 "mojave" is the last known major release
         # to support unversioned libssl.dylib. Anything above
         # needs specific versions
-        if major and int(major) > 14:
+        if int(ver) > 10 or int(ver) == 10 and int(major) > 14:
             lib = (
                 ctypes.util.find_library('libssl.46') or
                 ctypes.util.find_library('libssl.44') or

--- a/telethon/version.py
+++ b/telethon/version.py
@@ -1,3 +1,3 @@
 # Versions should comply with PEP440.
 # This line is parsed in setup.py:
-__version__ = '1.18.0'
+__version__ = '1.18.1'


### PR DESCRIPTION
Telethon is not working in macOS Big Sur.

The reason is that macOS Big Sur version is 11.x.y and in telethon we assume the first part is always 10.