### PR TITLE
docs: fix simple typo, recieved -> received

### DIFF
--- a/telethon_examples/payment.py
+++ b/telethon_examples/payment.py
@@ -83,7 +83,7 @@ async def payment_pre_checkout_handler(event: types.UpdateBotPrecheckoutQuery):
 async def payment_received_handler(event):
     if isinstance(event.message.action, types.MessageActionPaymentSentMe):
         payment: types.MessageActionPaymentSentMe = event.message.action
-        # do something after payment was recieved
+        # do something after payment was received
         if payment.payload.decode('UTF-8') == 'product A':
             await bot.send_message(event.message.from_id, 'Thank you for buying product A!')
         elif payment.payload.decode('UTF-8') == 'product B':


### PR DESCRIPTION
There is a small typo in telethon_examples/payment.py.

Should read `received` rather than `recieved`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md