### PR TITLE
Update resolve_invite_link() to support new links

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -1289,7 +1289,11 @@ def resolve_invite_link(link):
         payload = _decode_telegram_base64(link_hash)
 
     try:
-        return struct.unpack('>LLQ', payload)
+        if len(payload) == 12:
+            chat_id, rnd = struct.unpack('>LQ', payload)
+            return 0, chat_id, rnd
+        else:
+            return struct.unpack('>LLQ', payload)
     except (struct.error, TypeError):
         return None, None, None
 


### PR DESCRIPTION
Telegram removed creator user ID from invite links hash.
This commit should fix this.