### PR TITLE
Add new format to resolve invite link

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -1289,7 +1289,14 @@ def resolve_invite_link(link):
         payload = _decode_telegram_base64(link_hash)
 
     try:
-        return struct.unpack('>LLQ', payload)
+        if len(payload) == 12:
+            # New format
+            return 0, *struct.unpack('>LQ', payload)
+        elif len(payload) == 16:
+            # Old Format
+            return struct.unpack('>LLQ', payload)
+        else:
+            raise TypeError
     except (struct.error, TypeError):
         return None, None, None
 

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -1290,15 +1290,14 @@ def resolve_invite_link(link):
 
     try:
         if len(payload) == 12:
-            # New format
             return 0, *struct.unpack('>LQ', payload)
         elif len(payload) == 16:
-            # Old Format
             return struct.unpack('>LLQ', payload)
         else:
-            raise TypeError
+            pass
     except (struct.error, TypeError):
-        return None, None, None
+        pass
+    return None, None, None
 
 
 def resolve_inline_message_id(inline_msg_id):


### PR DESCRIPTION
The new format removed the creator id from it. It is now 0 for compatibility reasons. 