### PR TITLE
Support sending album by URL

### DIFF
--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -406,7 +406,7 @@ class UploadMethods:
             fh, fm, _ = await self._file_to_media(
                 file, supports_streaming=supports_streaming,
                 force_document=force_document)
-            if isinstance(fm, types.InputMediaUploadedPhoto):
+            if isinstance(fm, (types.InputMediaUploadedPhoto, types.InputMediaPhotoExternal)):
                 r = await self(functions.messages.UploadMediaRequest(
                     entity, media=fm
                 ))


### PR DESCRIPTION
Though Telegram doesn't support sending album by URL directly, we can upload each photo, get a list of `InputMedia`, and then send them normally using `SendMultiMediaRequest`.

This PR fixes #1408 