### PR TITLE
Make input entity errors less useless

### DIFF
--- a/telethon/client/users.py
+++ b/telethon/client/users.py
@@ -459,10 +459,10 @@ class UserMethods:
                 pass
 
         raise ValueError(
-            'Could not find the input entity for {!s}. Please read https://'
+            'Could not find the input entity for {} ({}). Please read https://'
             'docs.telethon.dev/en/latest/concepts/entities.html to'
             ' find out more details.'
-            .format(peer)
+            .format(peer, type(peer).__name__)
         )
 
     async def _get_peer(self: 'TelegramClient', peer: 'hints.EntityLike'):

--- a/telethon/client/users.py
+++ b/telethon/client/users.py
@@ -459,7 +459,7 @@ class UserMethods:
                 pass
 
         raise ValueError(
-            'Could not find the input entity for {!r}. Please read https://'
+            'Could not find the input entity for {!s}. Please read https://'
             'docs.telethon.dev/en/latest/concepts/entities.html to'
             ' find out more details.'
             .format(peer)


### PR DESCRIPTION
The `repr()` of TL types is just the class name and pointer, which is pretty much completely useless for any purpose. This changes the error to use `str()` instead, which shows the contents of the entity (i.e. the user ID)

Before:
> ValueError: Could not find the input entity for <telethon.tl.types.PeerUser object at 0x7f7f2e49eaf0>. Please read https://docs.telethon.dev/en/latest/concepts/entities.html to find out more details.

After:
> ValueError: Could not find the input entity for PeerUser(user_id=123456789). Please read https://docs.telethon.dev/en/latest/concepts/entities.html to find out more details.

