### PR TITLE
add pyaensi support to telethon

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -1,3 +1,4 @@
+pyaesni
 cryptg
 pysocks
 python-socks[asyncio]

--- a/readthedocs/basic/installation.rst
+++ b/readthedocs/basic/installation.rst
@@ -49,13 +49,16 @@ The version number of the library should show in the output.
 Optional Dependencies
 =====================
 
-If cryptg_ is installed, **the library will work a lot faster**, since
+If cryptg_ or pyaesni_ are installed, **the library will work a lot faster**, since
 encryption and decryption will be made in C instead of Python. If your
 code deals with a lot of updates or you are downloading/uploading a lot
 of files, you will notice a considerable speed-up (from a hundred kilobytes
 per second to several megabytes per second, if your connection allows it).
-If it's not installed, pyaes_ will be used (which is pure Python, so it's
+If none of them isinstalled, pyaes_ will be used (which is pure Python, so it's
 much slower).
+
+pyaesni_ uses `AES instruction set`_ so you would need a processor that supports it.
+Most 64bit processors support it by default so it shouldn't be a problem.
 
 If pillow_ is installed, large images will be automatically resized when
 sending photos to prevent Telegram from failing with "invalid image".
@@ -86,6 +89,8 @@ manually.
     Thanks to `@bb010g`_ for writing down this nice list.
 
 .. _cryptg: https://github.com/cher-nov/cryptg
+.. _pyaesni: https://github.com/painor/pyaesni
+.. _`AES instruction set`: https://en.wikipedia.org/wiki/AES_instruction_set
 .. _pyaes: https://github.com/ricmoo/pyaes
 .. _pillow: https://python-pillow.org
 .. _aiohttp: https://docs.aiohttp.org


### PR DESCRIPTION
so since **crypto is no longer present in the library I thought maybe it's time to add support to another fast AES library instead of doing dirty hacks like a package that overrides cryptg. 

pyaesni is cpython bindings to AES ni and from my testing is currently the fastest AES library. 
from my testings : 
used the same buffer,key,iv for all tests (taken from a telegram request). time in seconds for 100000 loops
```
pyaesni: encrypt took 0.23592730000000006 , decrypt took 0.23011160000000008
**crypto: encrypt took  0.2637916, decrypt took 0.2878893
cryptg: encrypt took 0.5449205000000001, decrypt took 0.7773716000000002
pyaes: encrypt took 41.4489714, decrypt took 45.173559
```
it's not that much faster but it's noticeable
pyaesni has wheels for windows and Linux and can be easily built with CMake if needed

https://github.com/painor/pyaesni