### PR TITLE
Improve exception clarity for parsing failure

### DIFF
--- a/telethon/client/messageparse.py
+++ b/telethon/client/messageparse.py
@@ -83,7 +83,11 @@ class MessageParseMethods:
         if not parse_mode:
             return message, []
 
+        original_message = message
         message, msg_entities = parse_mode.parse(message)
+        if original_message and not message and not msg_entities:
+            raise ValueError("Failed to parse message")
+        
         for i in reversed(range(len(msg_entities))):
             e = msg_entities[i]
             if isinstance(e, types.MessageEntityTextUrl):


### PR DESCRIPTION
This should improve clarity for issues like #1511 where parsing failure (such as an ampersand in html parsing mode) leads to an error saying:
`ValueError: The message cannot be empty unless a file is provided`
Which is very unclear, and rather misleading