### PR TITLE
fix: Message._needed_markup_bot not returning `bot` in some cases

### DIFF
--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -1125,6 +1125,7 @@ class Message(ChatGetter, SenderGetter, TLObject):
                         bot = self.input_sender
                         if not bot:
                             raise ValueError('No input sender')
+                        return bot
                     else:
                         try:
                             return self._client._entity_cache[self.via_bot_id]


### PR DESCRIPTION
fix: Message._needed_markup_bot not returning `bot` for the `KeyboardButtonSwitchInline` case when `button.same_peer` is True which is the case for buttons where `switch_inline_query_current_chat` is specified