### PR TITLE
sender.min is not set for ChannelForbidden, so use getattr for accessing it (#3051)

### DIFF
--- a/telethon/tl/custom/sendergetter.py
+++ b/telethon/tl/custom/sendergetter.py
@@ -44,7 +44,7 @@ class SenderGetter(abc.ABC):
         # in which case we want to force fetch the entire thing because
         # the user explicitly called a method. If the user is okay with
         # cached information, they may use the property instead.
-        if (self._sender is None or self._sender.min) \
+        if (self._sender is None or getattr(self._sender, 'min', None)) \
                 and await self.get_input_sender():
             try:
                 self._sender =\


### PR DESCRIPTION
Hello,

this is the PR for the bug discussed in #3051

Best,

Julian