### PR TITLE
Fix catch_up

### DIFF
--- a/telethon/sessions/abstract.py
+++ b/telethon/sessions/abstract.py
@@ -89,6 +89,13 @@ class Session(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_channel_pts(self):
+        """
+        Returns the ``Dict[int, int]`` with pts for all saved channels
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def set_update_state(self, entity_id, state):
         """
         Sets the given ``UpdateState`` for the specified `entity_id`, which

--- a/telethon/sessions/memory.py
+++ b/telethon/sessions/memory.py
@@ -74,6 +74,9 @@ class MemorySession(Session):
     def get_update_state(self, entity_id):
         return self._update_states.get(entity_id, None)
 
+    def get_channel_pts(self):
+        return {x[0]: x[1] for x in self._update_states.items() if x[0] != 0}
+
     def set_update_state(self, entity_id, state):
         self._update_states[entity_id] = state
 

--- a/telethon/sessions/sqlite.py
+++ b/telethon/sessions/sqlite.py
@@ -210,6 +210,14 @@ class SQLiteSession(MemorySession):
                 date, tz=datetime.timezone.utc)
             return types.updates.State(pts, qts, date, seq, unread_count=0)
 
+    def get_channel_pts(self):
+        c = self._cursor()
+        try:
+            rows = c.execute('select id, pts from update_state').fetchall()
+        finally:
+            c.close()
+        return {x[0]: x[1] for x in rows if x[0] != 0}
+
     def set_update_state(self, entity_id, state):
         self._execute('insert or replace into update_state values (?,?,?,?,?)',
                       entity_id, state.pts, state.qts,


### PR DESCRIPTION
updates.py:
- Fix catch_up getting stuck in infinite loop by saving qts
- Save new state to session after catch_up
- Save initial state immediately if catch_up was ran first time
- If DifferenceTooLong was received, continue fetching with new pts instead of exiting
- Catch up channels
- Implement pts limit (pts_total_limit in chats and limit in channels)
- Check if update was already processed before processing

telegrambaseclient.py, sessions:
- Get saved state from channels on startup and save channels state

statecache.py:
- Create separate variable _store in StateCache, because \_\_dict\_\_ also stores _logger variable
- Move has_pts, has_qts, has_date, has_channel_pts outside of function arguments

Fixes #3041