### PR TITLE
Update docs to reflect current length of login codes

### DIFF
--- a/readthedocs/developing/test-servers.rst
+++ b/readthedocs/developing/test-servers.rst
@@ -25,13 +25,17 @@ so don't store sensitive data here.
 
 Valid phone numbers are ``99966XYYYY``, where ``X`` is the ``dc_id`` and
 ``YYYY`` is any number you want, for example, ``1234`` in ``dc_id = 2`` would
-be ``9996621234``. The code sent by Telegram will be ``dc_id`` repeated six
-times, in this case, ``222222`` so we can hardcode that:
+be ``9996621234``. The code sent by Telegram will be ``dc_id`` repeated five
+times, in this case, ``22222`` so we can hardcode that:
 
 .. code-block:: python
 
     client = TelegramClient(None, api_id, api_hash)
     client.session.set_dc(2, '149.154.167.40', 80)
     client.start(
-        phone='9996621234', code_callback=lambda: '222222'
+        phone='9996621234', code_callback=lambda: '22222'
     )
+
+Note that Telegram has changed the length of login codes multiple times in the
+past, so if ``dc_id`` repeated five times does not work, try repeating it six
+times.


### PR DESCRIPTION
Telegram started using 5 number long codes (again), so let's update the docs to reflect that.