### PR TITLE
add_surrogate bug fix

### DIFF
--- a/telethon/helpers.py
+++ b/telethon/helpers.py
@@ -40,7 +40,7 @@ def add_surrogate(text):
         # SMP -> Surrogate Pairs (Telegram offsets are calculated with these).
         # See https://en.wikipedia.org/wiki/Plane_(Unicode)#Overview for more.
         ''.join(chr(y) for y in struct.unpack('<HH', x.encode('utf-16le')))
-        if (0x10000 <= ord(x) <= 0x10FFFF) else x for x in text
+        if (0x10000 <= ord(x) <= 0x10FFFF) else x for x in str(text)
     )
 
 


### PR DESCRIPTION
I fixed a bug.

Example code:
```python
from telethon import TelegramClient, events

client = TelegramClient("client", Config.TG_API_ID, Config.TG_API_HASH).start(
    bot_token=Config.TG_BOT_TOKEN)


@client.on(events.NewMessage(incoming=True))
async def handler(event: events.NewMessage.Event):
    await event.reply(event.chat_id) # <-- Error

client.run_until_disconnected()
```

Error log:
```
❯ python3 bot.py
Unhandled exception on handler
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/telethon/client/updates.py", line 454, in _dispatch_update
    await callback(event)
  File "/Users/yusuf/Desktop/x/bot.py", line 11, in handler
    await event.reply(event.chat_id)
  File "/usr/local/lib/python3.10/site-packages/telethon/tl/custom/message.py", line 757, in reply
    return await self._client.send_message(
  File "/usr/local/lib/python3.10/site-packages/telethon/client/messages.py", line 835, in send_message
    message, formatting_entities = await self._parse_message_text(message, parse_mode)
  File "/usr/local/lib/python3.10/site-packages/telethon/client/messageparse.py", line 87, in _parse_message_text
    message, msg_entities = parse_mode.parse(message)
  File "/usr/local/lib/python3.10/site-packages/telethon/extensions/markdown.py", line 68, in parse
    message = add_surrogate(message)
  File "/usr/local/lib/python3.10/site-packages/telethon/helpers.py", line 39, in add_surrogate
    return ''.join(
TypeError: 'int' object is not iterable
```