### PR TITLE
Add TypeInputUser to the EntityLike hint.

### DIFF
--- a/telethon/hints.py
+++ b/telethon/hints.py
@@ -16,8 +16,9 @@ EntityLike = typing.Union[
     PeerID,
     types.TypePeer,
     types.TypeInputPeer,
+    types.TypeInputUser,
     Entity,
-    FullEntity
+    FullEntity,
 ]
 EntitiesLike = typing.Union[EntityLike, typing.Sequence[EntityLike]]
 


### PR DESCRIPTION
Currently, the TypeInputUser is as follows:
`TypeInputUser = Union[InputUserEmpty, InputUserSelf, InputUser, InputUserFromMessage]`

As far as I understand, EntityLike is basically anything that Telethon can (potentially) convert into an input entity. It's used in many places in the library to provide convinience to the users. And in every place I could find Telethon then uses `get_input_entity`. In turn this method uses `utils.get_input_peer` which can already handle all of the types from TypeInputUser.

Thus, it makes sense to consider the TypeInputUser an entity-like.