### PR TITLE
Add support for new invite link format

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -54,7 +54,7 @@ mimetypes.add_type('audio/flac', '.flac')
 mimetypes.add_type('application/x-tgsticker', '.tgs')
 
 USERNAME_RE = re.compile(
-    r'@|(?:https?://)?(?:www\.)?(?:telegram\.(?:me|dog)|t\.me)/(@|joinchat/)?'
+    r'@|(?:https?://)?(?:www\.)?(?:telegram\.(?:me|dog)|t\.me)/(@|\+|joinchat/)?'
 )
 TG_JOIN_RE = re.compile(
     r'tg://(join)\?invite='


### PR DESCRIPTION
Recently, Telegram changed the invite link format for private groups so they look like `t.me/+InviteHash` instead of the old `t.me/joinchat/InviteHash` format, but the actual invite hashes are the same. Add support for the new "+" format to the username regex.