### PR TITLE
setup.py: Make build reproducible by sorting generator input

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ METHODS_IN = GENERATOR_DIR / 'data/methods.csv'
 # Which raw API methods are covered by *friendly* methods in the client?
 FRIENDLY_IN = GENERATOR_DIR / 'data/friendly.csv'
 
-TLOBJECT_IN_TLS = [Path(x) for x in GENERATOR_DIR.glob('data/*.tl')]
+TLOBJECT_IN_TLS = [Path(x) for x in sorted(GENERATOR_DIR.glob('data/*.tl'))]
 TLOBJECT_OUT = LIBRARY_DIR / '_tl'
 TLOBJECT_MOD = 'telethon._tl'
 


### PR DESCRIPTION
Debian's reproducible builds infrastructure reports that the ordering of
objects listed in the tlobjects dict in /usr/lib/python3/dist-packages/telethon/tl/alltlobjects.py
depends on the filesystem ordering of the *.tl files read at build time.

Fix that by sorting the list in setup.py.

https://reproducible-builds.org/