### PR TITLE
Add `PathLike` support to `SQLiteSession`

### DIFF
--- a/telethon/_sessions/sqlite.py
+++ b/telethon/_sessions/sqlite.py
@@ -39,7 +39,7 @@ class SQLiteSession(Session):
         self.save_entities = True
 
         if session_id:
-            self.filename = session_id
+            self.filename = os.fspath(session_id)
             if not self.filename.endswith(EXTENSION):
                 self.filename += EXTENSION
 


### PR DESCRIPTION
This pull request converts `SQLiteSession`'s `session_id` parameter to a string with [`os.fspath`](https://docs.python.org/3/library/os.html#os.fspath) so it works if `session_id` is a [`pathlib.Path`](https://docs.python.org/3/library/pathlib.html) or other [`os.PathLike`](https://docs.python.org/3/library/os.html#os.PathLike) object.