### PR TITLE
Change isisintance to isinstance in utils.py

### DIFF
--- a/telethon/_misc/utils.py
+++ b/telethon/_misc/utils.py
@@ -966,7 +966,7 @@ def get_peer_id(peer):
     Extract the integer ID from the given :tl:`Peer`.
     """
     pid = getattr(peer, 'user_id', None) or getattr(peer, 'channel_id', None) or getattr(peer, 'chat_id', None)
-    if not isisintance(pid, int):
+    if not isinstance(pid, int):
         _raise_cast_fail(peer, 'int')
 
     return pid


### PR DESCRIPTION
This PR fixes `isisintance` to the correct built-in `isinstance` function call in `telethon/_misc/utils.py`.