### PR TITLE
Fix IPv6 typo to IPv4 for StringSession.save()

### DIFF
--- a/telethon/_sessions/string.py
+++ b/telethon/_sessions/string.py
@@ -77,7 +77,7 @@ class StringSession(MemorySession):
         if self.dcs[self.state.dc_id].ipv6 is not None:
             ip = self.dcs[self.state.dc_id].ipv6.to_bytes(16, 'big', signed=False)
         else:
-            ip = self.dcs[self.state.dc_id].ipv6.to_bytes(4, 'big', signed=False)
+            ip = self.dcs[self.state.dc_id].ipv4.to_bytes(4, 'big', signed=False)
 
         return CURRENT_VERSION + StringSession.encode(struct.pack(
             _STRUCT_PREFORMAT.format(len(ip)),


### PR DESCRIPTION
In the `save` method of `StringSession`, if `self.dcs[self.state.dc_id].ipv6` is `None`, `ip` should refer to `self.dcs[self.state.dc_id].ipv4` instead of `self.dcs[self.state.dc_id].ipv6`. Otherwise, an `AttributeError` exception will be raised since a `NoneType` object has no `to_bytes` method.