### PR TITLE
Fix use InputMediaDocumentExternal in album

### DIFF
--- a/telethon/_client/uploads.py
+++ b/telethon/_client/uploads.py
@@ -194,7 +194,7 @@ async def _send_album(self: 'TelegramClient', entity, files, caption='',
             ))
 
             fm = utils.get_input_media(r.photo)
-        elif isinstance(fm, _tl.InputMediaUploadedDocument):
+        elif isinstance(fm, (_tl.InputMediaUploadedDocument, _tl.InputMediaDocumentExternal)):
             r = await self(_tl.fn.messages.UploadMedia(
                 entity, media=fm
             ))


### PR DESCRIPTION
Group video upload with http url is not currently supported

```python
album = [
    types.InputMediaPhotoExternal('https://example.com/example.png'),
    types.InputMediaDocumentExternal('https://example.com/example.mp4'),
]

await client.send_file('username', album)
```
Error:
```
telethon.errors.rpcerrorlist.MediaInvalidError: Media invalid (caused by SendMultiMediaRequest)
```

The problem of using ```InputMediaDocumentExternal``` in the album has been fixed
