### PR TITLE
fix event.user_added returning False

### DIFF
--- a/telethon/_events/chataction.py
+++ b/telethon/_events/chataction.py
@@ -192,7 +192,7 @@ class ChatAction(EventBuilder):
 
         if added_by is True or from_approval is True:
             self.user_joined = True
-        elif added_by:
+        elif added_by is None:
             self.user_added = True
             self._added_by = added_by
         self.user_approved = from_approval


### PR DESCRIPTION
In version 1.24.0 when adding a True user, this change tries to fix the event does not return this.