### PR TITLE
fix: TypeError

### DIFF
--- a/telethon/_network/mtprotostate.py
+++ b/telethon/_network/mtprotostate.py
@@ -143,7 +143,7 @@ class MTProtoState:
 
         msg_key = body[8:24]
         aes_key, aes_iv = self._calc_key(self.auth_key.key, msg_key, False)
-        body = AES.decrypt_ige(body[24:], aes_key, aes_iv)
+        body = AES.decrypt_ige(bytes(body[24:]), aes_key, aes_iv)
 
         # https://core.telegram.org/mtproto/security_guidelines
         # Sections "checking sha256 hash" and "message length"


### PR DESCRIPTION
Hi
I hope you are well

I found an issue while using `cryptg` that makes an exception, so I fix it by converting `bytearray` into `bytes` that fix the issue

```
telethon._network.mtprotosender - Unhandled error while receiving data - _recv_loop:mtprotosender.py
Traceback (most recent call last):
  File "\lib\site-packages\telethon\_network\mtprotosender.py", line 495, in _recv_loop
    message = self._state.decrypt_message_data(body)
  File "\lib\site-packages\telethon\_network\mtprotostate.py", line 146, in decrypt_message_data
    body = AES.decrypt_ige(body[24:], aes_key, aes_iv)
  File "\lib\site-packages\telethon\_crypto\aes.py", line 41, in decrypt_ige
    return cryptg.decrypt_ige(cipher_text, key, iv)
  File "\lib\site-packages\cryptg\__init__.py", line 19, in decrypt_ige
    _tinyaes_with_ige.lib.AES_IGE_decrypt_buffer(ctx, cipher, len(cipher))
TypeError: initializer for ctype 'uint8_t *' must be a cdata pointer, not bytearray
```