### PR TITLE
send_reaction: allow passing None to remove reactions from a message.

### DIFF
--- a/telethon/_client/messages.py
+++ b/telethon/_client/messages.py
@@ -755,10 +755,11 @@ async def send_reaction(
     entity: 'hints.DialogLike',
     message: 'hints.MessageIDLike',
     reaction: typing.Optional[str] = None,
-    big: bool = False
+    big: bool = False,
+    use_default: bool = False
 ):
     message = utils.get_message_id(message) or 0
-    if not reaction:
+    if not reaction and use_default:
         get_default_request = _tl.fn.help.GetAppConfig()
         app_config = await self(get_default_request)
         reaction = (

--- a/telethon/types/_custom/message.py
+++ b/telethon/types/_custom/message.py
@@ -1251,7 +1251,7 @@ class Message(ChatGetter, SenderGetter):
         return await self._client.unpin_message(
             await self.get_input_chat(), self.id)
 
-    async def react(self, reaction=None):
+    async def react(self, reaction=None, big=False, use_default=False):
         """
         Reacts on the given message. Shorthand for
         `telethon.client.messages.MessageMethods.send_reaction`
@@ -1261,7 +1261,9 @@ class Message(ChatGetter, SenderGetter):
             return await self._client.send_reaction(
                 await self.get_input_chat(),
                 self.id,
-                reaction
+                reaction,
+                big,
+                use_default
             )
 
     # endregion Public Methods

--- a/telethon/types/_custom/message.py
+++ b/telethon/types/_custom/message.py
@@ -1251,7 +1251,7 @@ class Message(ChatGetter, SenderGetter):
         return await self._client.unpin_message(
             await self.get_input_chat(), self.id)
 
-    async def react(self, reaction=None, big=False, use_default=False):
+    async def react(self, reaction=None, big=None, use_default=False):
         """
         Reacts on the given message. Shorthand for
         `telethon.client.messages.MessageMethods.send_reaction`


### PR DESCRIPTION
send_reaction should allow to pass None to remove reactions to a message.

Added an `use_default` argument that can be used with reaction=None to use one of the default reactions