### PR TITLE
fix parsing of markdown urls

### DIFF
--- a/telethon/extensions/markdown.py
+++ b/telethon/extensions/markdown.py
@@ -22,7 +22,7 @@ DEFAULT_DELIMITERS = {
     '```': MessageEntityPre
 }
 
-DEFAULT_URL_RE = re.compile(r'\[([\S\s]+?)\]\((.+?)\)')
+DEFAULT_URL_RE = re.compile(r'\[([^\]]+)\]\(([^)]+)\)')
 DEFAULT_URL_FORMAT = '[{0}]({1})'
 
 


### PR DESCRIPTION

the current default regex for pasrsing inline url is not correct. it failes when there are no urls after `[]` 

**Test input**
`[ Some text ] Some text [Some text](https://example.com)`

**Groups parsed by current regex**
![image](https://user-images.githubusercontent.com/10436637/189419946-45f6a8af-5286-48d8-aeb3-bc7f41d3b862.png)



**Groups parsed by modified regex**
![image](https://user-images.githubusercontent.com/10436637/189419970-eb4d1f93-7908-48ee-bd0e-e91e4046c18b.png)
