### PR TITLE
Update payment.py

### DIFF
--- a/telethon_examples/payment.py
+++ b/telethon_examples/payment.py
@@ -85,9 +85,9 @@ async def payment_received_handler(event):
         payment: types.MessageActionPaymentSentMe = event.message.action
         # do something after payment was received
         if payment.payload.decode('UTF-8') == 'product A':
-            await bot.send_message(event.message.from_id, 'Thank you for buying product A!')
+            await bot.send_message(event.message.peer_id.user_id, 'Thank you for buying product A!')
         elif payment.payload.decode('UTF-8') == 'product B':
-            await bot.send_message(event.message.from_id, 'Thank you for buying product B!')
+            await bot.send_message(event.message.peer_id.user_id, 'Thank you for buying product B!')
         raise events.StopPropagation
 
 


### PR DESCRIPTION
LINE 88 LINE 90
causing event.message.from_id error:
2022-12-19 16:51:10,027 - telethon.client.updates - ERROR - Unhandled exception on payment_received_handler Traceback (most recent call last):
  File "C:\Users\User\PycharmProjects\borpayment\venv\Lib\site-packages\telethon\client\updates.py", line 497, in _dispatch_update
    await callback(event)
  File "C:\Users\User\PycharmProjects\borpayment\main.py", line 87, in payment_received_handler
    await bot.send_message(event.message.from_id, 'Thank you for buying product A!')
  File "C:\Users\User\PycharmProjects\borpayment\venv\Lib\site-packages\telethon\client\messages.py", line 827, in send_message
    entity = await self.get_input_entity(entity)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\User\PycharmProjects\borpayment\venv\Lib\site-packages\telethon\client\users.py", line 443, in get_input_entity
    peer = utils.get_peer(peer)
           ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\User\PycharmProjects\borpayment\venv\Lib\site-packages\telethon\utils.py", line 997, in get_peer
    _raise_cast_fail(peer, 'Peer')
  File "C:\Users\User\PycharmProjects\borpayment\venv\Lib\site-packages\telethon\utils.py", line 138, in _raise_cast_fail
    raise TypeError('Cannot cast {} to any kind of {}.'.format(
TypeError: Cannot cast NoneType to any kind of Peer.

Changing from event.message.from_id to event.message.peer_id.user_id solves it