### PR TITLE
Fix telethon not saving update state outside of disconnect.

### DIFF
--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -467,6 +467,9 @@ class UpdateMethods:
             # inserted because this is a rather expensive operation
             # (default's sqlite3 takes ~0.1s to commit changes). Do
             # it every minute instead. No-op if there's nothing new.
+            
+            ss, cs = self._message_box.session_state()
+            self.session.set_update_state(0, types.updates.State(**ss, unread_count=0))
             self.session.save()
 
     async def _dispatch_update(self: 'TelegramClient', update):


### PR DESCRIPTION
This is only done on disconnect which causes catch_up to be render useless if the script closes abruptly and disconnect doesn't get called.