### PR TITLE
Correcting saving state and entities

### DIFF
--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -664,10 +664,8 @@ class TelegramBaseClient(abc.ABC):
         ss, cs = self._message_box.session_state()
         self.session.set_update_state(0, types.updates.State(**ss, unread_count=0))
         now = datetime.datetime.now()  # any datetime works; channels don't need it
-        entities_ids = {e.id for e in entities}
         for channel_id, pts in cs.items():
-            if channel_id in entities_ids:
-                self.session.set_update_state(channel_id, types.updates.State(pts, 0, now, 0, unread_count=0))
+            self.session.set_update_state(channel_id, types.updates.State(pts, 0, now, 0, unread_count=0))
 
     async def _disconnect_coro(self: 'TelegramClient'):
         if self.session is None:

--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -664,7 +664,7 @@ class TelegramBaseClient(abc.ABC):
         ss, cs = self._message_box.session_state()
         self.session.set_update_state(0, types.updates.State(**ss, unread_count=0))
         now = datetime.datetime.now()  # any datetime works; channels don't need it
-        entities_ids = [e.id for e in entities]
+        entities_ids = (e.id for e in entities)
         for channel_id, pts in cs.items():
             if channel_id in entities_ids:
                 self.session.set_update_state(channel_id, types.updates.State(pts, 0, now, 0, unread_count=0))

--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -664,7 +664,7 @@ class TelegramBaseClient(abc.ABC):
         ss, cs = self._message_box.session_state()
         self.session.set_update_state(0, types.updates.State(**ss, unread_count=0))
         now = datetime.datetime.now()  # any datetime works; channels don't need it
-        entities_ids = (e.id for e in entities)
+        entities_ids = {e.id for e in entities}
         for channel_id, pts in cs.items():
             if channel_id in entities_ids:
                 self.session.set_update_state(channel_id, types.updates.State(pts, 0, now, 0, unread_count=0))

--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -664,8 +664,10 @@ class TelegramBaseClient(abc.ABC):
         ss, cs = self._message_box.session_state()
         self.session.set_update_state(0, types.updates.State(**ss, unread_count=0))
         now = datetime.datetime.now()  # any datetime works; channels don't need it
+        entities_ids = [e.id for e in entities]
         for channel_id, pts in cs.items():
-            self.session.set_update_state(channel_id, types.updates.State(pts, 0, now, 0, unread_count=0))
+            if channel_id in entities_ids:
+                self.session.set_update_state(channel_id, types.updates.State(pts, 0, now, 0, unread_count=0))
 
     async def _disconnect_coro(self: 'TelegramClient'):
         if self.session is None:

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -467,6 +467,8 @@ class UpdateMethods:
             # inserted because this is a rather expensive operation
             # (default's sqlite3 takes ~0.1s to commit changes). Do
             # it every minute instead. No-op if there's nothing new.
+            self._save_states_and_entities()
+
             self.session.save()
 
     async def _dispatch_update(self: 'TelegramClient', update):


### PR DESCRIPTION
Add periodic save state and entitites, not just when using disconnect.
Correcting the situation when the channel was not written to entities, because it came in the form of min, and state was written and the next time it was turned on with the catch_up parameter, the script did not run