### PR TITLE
Fix conversion and time zone issues

### DIFF
--- a/telethon/_updates/messagebox.py
+++ b/telethon/_updates/messagebox.py
@@ -232,7 +232,7 @@ class MessageBox:
             self.map[ENTRY_SECRET] = State(pts=session_state.qts, deadline=deadline)
         self.map.update((s.channel_id, State(pts=s.pts, deadline=deadline)) for s in channel_states)
 
-        self.date = datetime.datetime.utcfromtimestamp(session_state.date).replace(tzinfo=datetime.timezone.utc)
+        self.date = datetime.datetime.fromtimestamp(session_state.date, tz=datetime.timezone.utc)
         self.seq = session_state.seq
         self.next_deadline = ENTRY_ACCOUNT
 

--- a/telethon/_updates/messagebox.py
+++ b/telethon/_updates/messagebox.py
@@ -232,7 +232,7 @@ class MessageBox:
             self.map[ENTRY_SECRET] = State(pts=session_state.qts, deadline=deadline)
         self.map.update((s.channel_id, State(pts=s.pts, deadline=deadline)) for s in channel_states)
 
-        self.date = datetime.datetime.fromtimestamp(session_state.date).replace(tzinfo=datetime.timezone.utc)
+        self.date = datetime.datetime.utcfromtimestamp(session_state.date).replace(tzinfo=datetime.timezone.utc)
         self.seq = session_state.seq
         self.next_deadline = ENTRY_ACCOUNT
 


### PR DESCRIPTION
When downloading updates, GetDifference request was sent with time, taking into account the time zone, but the time zone was specified UTC. This happened because "fromtimestamp" creates datetime taking into account the time zone, so it was replaced by "utcfromtimestamp"