### PR TITLE
If update from channel and any user or channel is_min=True, start GetChannelDifference for load users and channels.

### DIFF
--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -435,7 +435,7 @@ class UpdateMethods:
             if isinstance(peer, types.User):
                 result_users[utils.get_peer_id(peer)] = peer
             elif isinstance(peer, (types.Chat, types.Channel)):
-                result_chats.update({utils.get_peer_id(peer): peer})
+                result_chats[utils.get_peer_id(peer)] = peer
 
         return is_min, result_users, result_chats
 

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -433,7 +433,7 @@ class UpdateMethods:
                 if not self._mb_entity_cache.get(peer_id) and peer.id != 136817688:
                     is_min = True
             if isinstance(peer, types.User):
-                result_users.update({utils.get_peer_id(peer): peer})
+                result_users[utils.get_peer_id(peer)] = peer
             elif isinstance(peer, (types.Chat, types.Channel)):
                 result_chats.update({utils.get_peer_id(peer): peer})
 

--- a/telethon/client/updates.py
+++ b/telethon/client/updates.py
@@ -450,22 +450,22 @@ class UpdateMethods:
                     types.UpdateReadChannelOutbox,
             )):
                 if is_min and update.pts:
-                        get_diff = functions.updates.GetChannelDifferenceRequest(
-                            force=False,
-                            channel=await self.get_input_entity(update.message.peer_id),
-                            filter=types.ChannelMessagesFilter(
-                                ranges=[types.MessageRange(
-                                    min_id=update.message.id,
-                                    max_id=update.message.id
-                                )]
-                            ),
-                            pts=update.pts - update.pts_count,
-                            limit=update.pts
-                        )
-                        diff = await self(get_diff)
-                        if not isinstance(diff, types.updates.ChannelDifferenceEmpty):
-                            chats.update({utils.get_peer_id(x): x for x in diff.chats})
-                            users.update({utils.get_peer_id(x): x for x in diff.users})
+                    get_diff = functions.updates.GetChannelDifferenceRequest(
+                        force=False,
+                        channel=await self.get_input_entity(update.message.peer_id),
+                        filter=types.ChannelMessagesFilter(
+                            ranges=[types.MessageRange(
+                                min_id=update.message.id,
+                                max_id=update.message.id
+                            )]
+                        ),
+                        pts=update.pts - update.pts_count,
+                        limit=update.pts
+                    )
+                    diff = await self(get_diff)
+                    if not isinstance(diff, types.updates.ChannelDifferenceEmpty):
+                        chats.update({utils.get_peer_id(x): x for x in diff.chats})
+                        users.update({utils.get_peer_id(x): x for x in diff.users})
 
         self._mb_entity_cache.extend(list(users.values()), list(chats.values()))
         entities = users | chats


### PR DESCRIPTION
This will fix the situation when the entity is not written, but the state is written and the script at startup and catch_up=True will not be able to find the entity and stop with an error