### PR TITLE
Save photos as progressive when uploading

### DIFF
--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -77,7 +77,7 @@ def _resize_photo_if_needed(
             result.paste(image, mask=image.split()[alpha_index])
 
         buffer = io.BytesIO()
-        result.save(buffer, 'JPEG', **kwargs)
+        result.save(buffer, 'JPEG', progressive=True, **kwargs)
         buffer.seek(0)
         return buffer
 

--- a/telethon/version.py
+++ b/telethon/version.py
@@ -1,3 +1,3 @@
 # Versions should comply with PEP440.
 # This line is parsed in setup.py:
-__version__ = '1.28.3'
+__version__ = '1.28.4'


### PR DESCRIPTION
this fixes downloading images in some clients at resolutions >1280, namely tdesktop