### PR TITLE
Allowing nosound_video to be specified 

### DIFF
--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -755,14 +755,14 @@ class MessageMethods:
                 This parameter takes precedence over ``reply_to``. If there is
                 no linked chat, `telethon.errors.sgIdInvalidError` is raised.
 
-            nosoundvideo (`bool`, optional):
+            nosound_video (`bool`, optional):
                 Only applicable when sending a video file without an audio
-                track. If set to true, the video will be displayed in telegram
-                as a video. If set to false, telegram will attempt to display
-                the video as an animated gif. (It may still display as a video
-                due to other factors.) The value is ignored if set on
-                non-video files. This is set to true for albums, as gifs cannot
-                be sent in albums.
+                track. If set to ``True``, the video will be displayed in
+                Telegram as a video. If set to ``False``, Telegram will attempt
+                to display the video as an animated gif. (It may still display
+                as a video due to other factors.) The value is ignored if set
+                on non-video files. This is set to ``True`` for albums, as gifs
+                cannot be sent in albums.
 
         Returns
             The sent `custom.Message <telethon.tl.custom.message.Message>`.

--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -640,7 +640,8 @@ class MessageMethods:
             background: bool = None,
             supports_streaming: bool = False,
             schedule: 'hints.DateLike' = None,
-            comment_to: 'typing.Union[int, types.Message]' = None
+            comment_to: 'typing.Union[int, types.Message]' = None,
+            nosound_video: bool = None,
     ) -> 'types.Message':
         """
         Sends a message to the specified user, chat or channel.
@@ -754,6 +755,15 @@ class MessageMethods:
                 This parameter takes precedence over ``reply_to``. If there is
                 no linked chat, `telethon.errors.sgIdInvalidError` is raised.
 
+            nosoundvideo (`bool`, optional):
+                Only applicable when sending a video file without an audio
+                track. If set to true, the video will be displayed in telegram
+                as a video. If set to false, telegram will attempt to display
+                the video as an animated gif. (It may still display as a video
+                due to other factors.) The value is ignored if set on
+                non-video files. This is set to true for albums, as gifs cannot
+                be sent in albums.
+
         Returns
             The sent `custom.Message <telethon.tl.custom.message.Message>`.
 
@@ -821,7 +831,8 @@ class MessageMethods:
                 buttons=buttons, clear_draft=clear_draft, silent=silent,
                 schedule=schedule, supports_streaming=supports_streaming,
                 formatting_entities=formatting_entities,
-                comment_to=comment_to, background=background
+                comment_to=comment_to, background=background,
+                nosound_video=nosound_video,
             )
 
         entity = await self.get_input_entity(entity)

--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -117,6 +117,7 @@ class UploadMethods:
             schedule: 'hints.DateLike' = None,
             comment_to: 'typing.Union[int, types.Message]' = None,
             ttl: int = None,
+            nosound_video: bool = None,
             **kwargs) -> 'types.Message':
         """
         Sends message with the given file to the specified entity.
@@ -286,6 +287,15 @@ class UploadMethods:
                 Not all types of media can be used with this parameter, such
                 as text documents, which will fail with ``TtlMediaInvalidError``.
 
+            nosound_video (`bool`. optional):
+                This value only applies if sending a video without an audio
+                track. If True, the video will be displayed in telegram as a
+                video. If False, telegram will attempt to display it as an
+                animated gif. (Though it may still display as a video,
+                depending on other factors.) The value is ignored if the file
+                is not a video. The value is set to True for albums, as gifs
+                cannot be sent in albums.
+
         Returns
             The `Message <telethon.tl.custom.message.Message>` (or messages)
             containing the sent file, or messages if a list of them was passed.
@@ -389,7 +399,8 @@ class UploadMethods:
             progress_callback=progress_callback,
             attributes=attributes,  allow_cache=allow_cache, thumb=thumb,
             voice_note=voice_note, video_note=video_note,
-            supports_streaming=supports_streaming, ttl=ttl
+            supports_streaming=supports_streaming, ttl=ttl,
+            nosound_video=nosound_video,
         )
 
         # e.g. invalid cast from :tl:`MessageMediaWebPage`
@@ -439,13 +450,13 @@ class UploadMethods:
         media = []
         for sent_count, file in enumerate(files):
             # Albums want :tl:`InputMedia` which, in theory, includes
-            # :tl:`InputMediaUploadedPhoto`. However using that will
+            # :tl:`InputMediaUploadedPhoto`. However, using that will
             # make it `raise MediaInvalidError`, so we need to upload
             # it as media and then convert that to :tl:`InputMediaPhoto`.
             fh, fm, _ = await self._file_to_media(
                 file, supports_streaming=supports_streaming,
                 force_document=force_document, ttl=ttl,
-                progress_callback=used_callback)
+                progress_callback=used_callback, nosound_video=True)
             if isinstance(fm, (types.InputMediaUploadedPhoto, types.InputMediaPhotoExternal)):
                 r = await self(functions.messages.UploadMediaRequest(
                     entity, media=fm
@@ -675,7 +686,7 @@ class UploadMethods:
             progress_callback=None, attributes=None, thumb=None,
             allow_cache=True, voice_note=False, video_note=False,
             supports_streaming=False, mime_type=None, as_image=None,
-            ttl=None):
+            ttl=None, nosound_video=None):
         if not file:
             return None, None, None
 
@@ -762,7 +773,7 @@ class UploadMethods:
 
             # setting `nosound_video` to `True` doesn't affect videos with sound
             # instead it prevents sending silent videos as GIFs
-            nosound_video = True if mime_type.split("/")[0] == 'video' else None
+            nosound_video = nosound_video if mime_type.split("/")[0] == 'video' else None
 
             media = types.InputMediaUploadedDocument(
                 file=file_handle,

--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -287,13 +287,13 @@ class UploadMethods:
                 Not all types of media can be used with this parameter, such
                 as text documents, which will fail with ``TtlMediaInvalidError``.
 
-            nosound_video (`bool`. optional):
-                This value only applies if sending a video without an audio
-                track. If True, the video will be displayed in telegram as a
-                video. If False, telegram will attempt to display it as an
-                animated gif. (Though it may still display as a video,
-                depending on other factors.) The value is ignored if the file
-                is not a video. The value is set to True for albums, as gifs
+            nosound_video (`bool`, optional):
+                Only applicable when sending a video file without an audio
+                track. If set to ``True``, the video will be displayed in
+                Telegram as a video. If set to ``False``, Telegram will attempt
+                to display the video as an animated gif. (It may still display
+                as a video due to other factors.) The value is ignored if set
+                on non-video files. This is set to ``True`` for albums, as gifs
                 cannot be sent in albums.
 
         Returns

--- a/telethon/version.py
+++ b/telethon/version.py
@@ -1,3 +1,3 @@
 # Versions should comply with PEP440.
 # This line is parsed in setup.py:
-__version__ = '1.28.4'
+__version__ = '1.28.5'


### PR DESCRIPTION
So, this commit in 1.26.0:
https://github.com/LonamiWebs/Telethon/commit/ef4f9a962c6ef41b1b1905186a26c0695b1e4be2
changed the behaviour of sending video files without audio streams, so instead of defaulting to gifs, they defaulted to sending as videos. This was changed in PR #3951, to fix issue #3232, which was an issue when sending audio-free videos in albums. '(As gifs cannot be sent in albums, it would break the album)
So the solution there was to hardcode all videos without audio to send as videos. Which is problematic for tools which generate and send gifs.

So, I've made a change here to allow specifying whether to send sound-free videos as videos, or as animated gifs. By default, it will go back to the old behaviour of sending them as animated gifs. In albums, it will be hardcoded to sending them as videos.

I've added the parameter to both the `send_file()` and the `send_message()` methods.


