### PR TITLE
Implement media spoilers in friendly methods

### DIFF
--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -642,6 +642,7 @@ class MessageMethods:
             schedule: 'hints.DateLike' = None,
             comment_to: 'typing.Union[int, types.Message]' = None,
             nosound_video: bool = None,
+            spoiler: typing.Union[bool, typing.Sequence[bool]] = None
     ) -> 'types.Message':
         """
         Sends a message to the specified user, chat or channel.
@@ -764,6 +765,11 @@ class MessageMethods:
                 on non-video files. This is set to ``True`` for albums, as gifs
                 cannot be sent in albums.
 
+            spoiler (`bool`, optional):
+                Whether or not to spoiler the media in the sent message. When sending an
+                album, this may be a list of booleans, which will be
+                assigned to the media pairwise.
+
         Returns
             The sent `custom.Message <telethon.tl.custom.message.Message>`.
 
@@ -832,7 +838,7 @@ class MessageMethods:
                 schedule=schedule, supports_streaming=supports_streaming,
                 formatting_entities=formatting_entities,
                 comment_to=comment_to, background=background,
-                nosound_video=nosound_video,
+                nosound_video=nosound_video, spoiler=spoiler
             )
 
         entity = await self.get_input_entity(entity)
@@ -1061,7 +1067,8 @@ class MessageMethods:
             force_document: bool = False,
             buttons: typing.Optional['hints.MarkupLike'] = None,
             supports_streaming: bool = False,
-            schedule: 'hints.DateLike' = None
+            schedule: 'hints.DateLike' = None,
+            spoiler: bool = None
     ) -> 'types.Message':
         """
         Edits the given message to change its text or media.
@@ -1145,6 +1152,9 @@ class MessageMethods:
                 Note that this parameter will have no effect if you are
                 trying to edit a message that was sent via inline bots.
 
+            spoiler (`bool`, optional):
+                Whether or not to spoiler the media in the sent message.
+
         Returns
             The edited `Message <telethon.tl.custom.message.Message>`,
             unless `entity` was a :tl:`InputBotInlineMessageID` or :tl:`InputBotInlineMessageID64` in which
@@ -1183,11 +1193,14 @@ class MessageMethods:
 
         if formatting_entities is None:
             text, formatting_entities = await self._parse_message_text(text, parse_mode)
+
         file_handle, media, image = await self._file_to_media(file,
-                supports_streaming=supports_streaming,
-                thumb=thumb,
-                attributes=attributes,
-                force_document=force_document)
+            supports_streaming=supports_streaming,
+            thumb=thumb,
+            attributes=attributes,
+            force_document=force_document,
+            spoiler=spoiler
+        )
 
         if isinstance(entity, (types.InputBotInlineMessageID, types.InputBotInlineMessageID64)):
             request = functions.messages.EditInlineBotMessageRequest(

--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -430,7 +430,7 @@ def get_input_media(
         media, *,
         is_photo=False, attributes=None, force_document=False,
         voice_note=False, video_note=False, supports_streaming=False,
-        ttl=None
+        ttl=None, spoiler=None
 ):
     """
     Similar to :meth:`get_input_peer`, but for media.
@@ -452,30 +452,38 @@ def get_input_media(
     if isinstance(media, types.MessageMediaPhoto):
         return types.InputMediaPhoto(
             id=get_input_photo(media.photo),
-            ttl_seconds=ttl or media.ttl_seconds
+            ttl_seconds=ttl or media.ttl_seconds,
+            spoiler=spoiler or media.spoiler
         )
 
     if isinstance(media, (types.Photo, types.photos.Photo, types.PhotoEmpty)):
         return types.InputMediaPhoto(
             id=get_input_photo(media),
-            ttl_seconds=ttl
+            ttl_seconds=ttl,
+            spoiler=spoiler
         )
 
     if isinstance(media, types.MessageMediaDocument):
         return types.InputMediaDocument(
             id=get_input_document(media.document),
-            ttl_seconds=ttl or media.ttl_seconds
+            ttl_seconds=ttl or media.ttl_seconds,
+            spoiler=spoiler or media.spoiler
         )
 
     if isinstance(media, (types.Document, types.DocumentEmpty)):
         return types.InputMediaDocument(
             id=get_input_document(media),
-            ttl_seconds=ttl
+            ttl_seconds=ttl,
+            spoiler=spoiler
         )
 
     if isinstance(media, (types.InputFile, types.InputFileBig)):
         if is_photo:
-            return types.InputMediaUploadedPhoto(file=media, ttl_seconds=ttl)
+            return types.InputMediaUploadedPhoto(
+                file=media,
+                ttl_seconds=ttl,
+                spoiler=spoiler
+            )
         else:
             attrs, mime = get_attributes(
                 media,
@@ -486,8 +494,13 @@ def get_input_media(
                 supports_streaming=supports_streaming
             )
             return types.InputMediaUploadedDocument(
-                file=media, mime_type=mime, attributes=attrs, force_file=force_document,
-                ttl_seconds=ttl)
+                file=media,
+                mime_type=mime,
+                attributes=attrs,
+                force_file=force_document,
+                ttl_seconds=ttl,
+                spoiler=spoiler
+            )
 
     if isinstance(media, types.MessageMediaGame):
         return types.InputMediaGame(id=types.InputGameID(


### PR DESCRIPTION
May need a bit more testing, but works fine for me when sending media, albums and editing. Local and external media via URL.