### PR TITLE
Fix import of telethon.tl.types in telethon/sessions/sqlite.py

### DIFF
--- a/telethon/sessions/sqlite.py
+++ b/telethon/sessions/sqlite.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import time
 
-from telethon.tl import types
+from ..tl import types
 from .memory import MemorySession, _SentFileType
 from .. import utils
 from ..crypto import AuthKey


### PR DESCRIPTION
This is the only place where you using module name.
I would like to remove it, since when building and using multiple versions of this library I always needed to patch this.