### PR TITLE
Added type hint to `NewMessage.Event.message`

### DIFF
--- a/telethon/events/newmessage.py
+++ b/telethon/events/newmessage.py
@@ -196,7 +196,7 @@ class NewMessage(EventBuilder):
                 ...
                 >>>
         """
-        def __init__(self, message):
+        def __init__(self, message: types.Message):
             self.__dict__['_init'] = False
             super().__init__(chat_peer=message.peer_id,
                              msg_id=message.id, broadcast=bool(message.post))


### PR DESCRIPTION
Before, when retrieving a message from the event, the type was "Unknown".

I'm not sure why the type hints are not written in the project (where I looked), but I really want them to be present. Otherwise, I have to manually set type for each child of an object to get autocompletion to work.