### PR TITLE
Fix comment_to for a group of messages

### DIFF
--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -617,7 +617,7 @@ class MessageMethods:
             peer=entity,
             msg_id=utils.get_message_id(message)
         ))
-        m = r.messages[0]
+        m = r.messages[-1]
         chat = next(c for c in r.chats if c.id == m.peer_id.channel_id)
         return utils.get_input_peer(chat), m.id
 

--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -617,7 +617,7 @@ class MessageMethods:
             peer=entity,
             msg_id=utils.get_message_id(message)
         ))
-        m = r.messages[-1]
+        m = min(r.messages, key=lambda msg: msg.id)
         chat = next(c for c in r.chats if c.id == m.peer_id.channel_id)
         return utils.get_input_peer(chat), m.id
 


### PR DESCRIPTION
`GetDiscussionMessageRequest` returns a list of messages in reverse order (which is crucial in case if it is a group of photos/docs/etc), you need to reply to the first message so that a comment is displayed correctly.