### PR TITLE
Use lanczos for compression and always compress when > 10 MB

### DIFF
--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -58,10 +58,7 @@ def _resize_photo_if_needed(
         except KeyError:
             kwargs = {}
 
-        if image.width <= width and image.height <= height:
-            return file
-
-        image.thumbnail((width, height), PIL.Image.ANTIALIAS)
+        image.thumbnail((width, height), PIL.Image.LANCZOS)
 
         alpha_index = image.mode.find('A')
         if alpha_index == -1:

--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -47,7 +47,17 @@ def _resize_photo_if_needed(
     if isinstance(file, bytes):
         file = io.BytesIO(file)
 
-    before = file.tell() if isinstance(file, io.IOBase) else None
+    if isinstance(file, io.IOBase):
+        # Pillow seeks to 0 unconditionally later anyway
+        old_pos = file.tell()
+        file.seek(0, io.SEEK_END)
+        before = file.tell()
+    elif isinstance(file, str) and os.path.exists(file):
+        # Check if file exists as a path and if so, get its size on disk
+        before = os.path.getsize(file)
+    else:
+        # Would be weird...
+        before = None
 
     try:
         # Don't use a `with` block for `image`, or `file` would be closed.
@@ -57,6 +67,10 @@ def _resize_photo_if_needed(
             kwargs = {'exif': image.info['exif']}
         except KeyError:
             kwargs = {}
+
+        # Check if image is within acceptable bounds, if so, check if the image is at or below 10 MB, or assume it isn't if size is None or 0
+        if image.width <= width and image.height <= height and (before <= 10000000 if before else False):
+            return file
 
         image.thumbnail((width, height), PIL.Image.LANCZOS)
 
@@ -77,12 +91,12 @@ def _resize_photo_if_needed(
         result.save(buffer, 'JPEG', progressive=True, **kwargs)
         buffer.seek(0)
         return buffer
-
     except IOError:
         return file
     finally:
-        if before is not None:
-            file.seek(before, io.SEEK_SET)
+        # The original position might matter
+        if isinstance(file, io.IOBase):
+            file.seek(old_pos)
 
 
 class UploadMethods:


### PR DESCRIPTION
Pillow removed Image.ANTIALIAS recently in version 10.0.0, Image.LANCZOS is the suggested alternative
Uploading photos that were within the acceptable photo dimensions but exceeded the size Telegram limits photos to was causing those photo uploads to fail, so always crush photos