### PR TITLE
Sort objects before output

### DIFF
--- a/telethon_generator/generators/tlobject.py
+++ b/telethon_generator/generators/tlobject.py
@@ -667,6 +667,7 @@ def _write_all_tlobjects(tlobjects, layer, builder):
     builder.current_indent += 1
 
     # Fill the dictionary (0x1a2b3c4f: tl.full.type.path.Class)
+    tlobjects.sort(key=lambda x: x.name)
     for tlobject in tlobjects:
         builder.write('{:#010x}: ', tlobject.id)
         builder.write('functions' if tlobject.is_function else 'types')


### PR DESCRIPTION
Sort objects before output to ensure reproducible build results

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE.