### PR TITLE
KeyboardButtonWebView is an inline button

### DIFF
--- a/telethon/tl/custom/button.py
+++ b/telethon/tl/custom/button.py
@@ -54,7 +54,8 @@ class Button:
             types.KeyboardButtonGame,
             types.KeyboardButtonSwitchInline,
             types.KeyboardButtonUrl,
-            types.InputKeyboardButtonUrlAuth
+            types.InputKeyboardButtonUrlAuth,
+            types.KeyboardButtonWebView,
         ))
 
     @staticmethod


### PR DESCRIPTION
Fix for `telethon.errors.rpcerrorlist.ButtonTypeInvalidError: The type of one of the buttons you provided is invalid (caused by SendMessageRequest)` when trying to send KeyboardButtonWebView

https://core.telegram.org/constructor/keyboardButtonWebView

> Can only be sent or received as part of an **inline keyboard**, use keyboardButtonSimpleWebView for reply keyboards.
