### PR TITLE
Fix date empty

### DIFF
--- a/telethon/_updates/messagebox.py
+++ b/telethon/_updates/messagebox.py
@@ -689,7 +689,7 @@ class MessageBox:
             updates=diff.other_updates,
             users=diff.users,
             chats=diff.chats,
-            date=epoch(),
+            date=epoch() + datetime.timedelta(seconds=1),
             seq=NO_SEQ,  # this way date is not used
         ), chat_hashes, updates)
 
@@ -798,7 +798,7 @@ class MessageBox:
                 updates=diff.other_updates,
                 users=diff.users,
                 chats=diff.chats,
-                date=epoch(),
+                date=epoch() + datetime.timedelta(seconds=1),
                 seq=NO_SEQ,  # this way date is not used
             ), chat_hashes, updates)
 


### PR DESCRIPTION
Previously, the date there was equal to timestamp 1, after the last commits it was equated to timestamp 0, which is why errors appear.
telethon.errors.rpcerrorlist.DateEmptyError: Date empty (caused by GetDifferenceRequest)