### PR TITLE
Fix generator for pypy

### DIFF
--- a/telethon_generator/generators/tlobject.py
+++ b/telethon_generator/generators/tlobject.py
@@ -197,7 +197,7 @@ def _write_class_init(tlobject, kind, type_constructors, builder):
     if not tlobject.real_args:
         return
 
-    if any(a.name in __builtins__ for a in tlobject.real_args):
+    if any(hasattr(__builtins__, a.name) for a in tlobject.real_args):
         builder.writeln('# noinspection PyShadowingBuiltins')
 
     builder.writeln("def __init__({}):", ', '.join(['self'] + args))


### PR DESCRIPTION
When installing Telethon in PyPy, this error will appear:

        File "telethon_generator/generators/tlobject.py", line 200, in <genexpr>
          if any(a.name in __builtins__ for a in tlobject.real_args):
                 ^^^^^^^^^^^^^^^^^^^^^^
      TypeError: 'module' object is not iterable

This pull request fixes this problem.
