### PR TITLE
Syntax highlighting support for markdown parse_mode

### DIFF
--- a/telethon/extensions/markdown.py
+++ b/telethon/extensions/markdown.py
@@ -99,7 +99,17 @@ def parse(message, delimiters=None, url_re=None):
                 # Append the found entity
                 ent = delimiters[delim]
                 if ent == MessageEntityPre:
-                    result.append(ent(i, end - i - len(delim), ''))  # has 'lang'
+                    # Parse ```language
+                    lang = ''
+                    try:
+                        newline = message.index('\n', i, end)
+                        if newline > i:
+                            lang = message[i:newline]
+                            message = message[:i] + message[newline+1:]
+                            end -= len(lang) + 1
+                    except ValueError:
+                        pass
+                    result.append(ent(i, end - i - len(delim), lang))
                 else:
                     result.append(ent(i, end - i - len(delim)))
 


### PR DESCRIPTION
Adds support for syntax-highlight code blocks, with similar behaviour as the official telegram clients.

I'm not sure if there's a way of validating the language as I couldn't find any list of supported language identifiers and different telegram clients handle unknown languages in different ways. The behaviour of this PR is similar to telegram on android, which always sets the language even if it isn't recognized.