### PR TITLE
fix(Group): missing slot property

### DIFF
--- a/client/src/telethon/_impl/client/types/chat/group.py
+++ b/client/src/telethon/_impl/client/types/chat/group.py
@@ -21,7 +21,7 @@ class Group(Chat, metaclass=NoPublicConstructor):
     or from methods such as :meth:`telethon.Client.resolve_username`.
     """
 
-    __slots__ = ("_raw","_client")
+    __slots__ = ("_raw","_client",)
 
     def __init__(
         self,

--- a/client/src/telethon/_impl/client/types/chat/group.py
+++ b/client/src/telethon/_impl/client/types/chat/group.py
@@ -21,7 +21,7 @@ class Group(Chat, metaclass=NoPublicConstructor):
     or from methods such as :meth:`telethon.Client.resolve_username`.
     """
 
-    __slots__ = ("_raw",)
+    __slots__ = ("_raw","_client")
 
     def __init__(
         self,


### PR DESCRIPTION
this will fix issues with groups not being able to construct, due to missing `_client` slot