### PR TITLE
[V2] add ChatType to exported filters; rename sender -> chat in ChatType.__call__

### DIFF
--- a/client/src/telethon/_impl/client/events/filters/__init__.py
+++ b/client/src/telethon/_impl/client/events/filters/__init__.py
@@ -1,5 +1,5 @@
 from .combinators import All, Any, Filter, Not
-from .common import Chats, Senders
+from .common import Chats, Senders, ChatType
 from .messages import Command, Forward, Incoming, Media, Outgoing, Reply, Text, TextOnly
 
 __all__ = [
@@ -9,6 +9,7 @@ __all__ = [
     "Not",
     "Chats",
     "Senders",
+    "ChatType",
     "Command",
     "Forward",
     "Incoming",

--- a/client/src/telethon/_impl/client/events/filters/common.py
+++ b/client/src/telethon/_impl/client/events/filters/common.py
@@ -88,5 +88,5 @@ class ChatType(Combinable):
             raise RuntimeError("unexpected case")
 
     def __call__(self, event: Event) -> bool:
-        sender = getattr(event, "chat", None)
-        return isinstance(sender, self._type)
+        chat = getattr(event, "chat", None)
+        return isinstance(chat, self._type)

--- a/client/src/telethon/events/filters.py
+++ b/client/src/telethon/events/filters.py
@@ -20,6 +20,7 @@ from .._impl.client.events.filters import (
     Outgoing,
     Reply,
     Senders,
+    ChatType,
     Text,
     TextOnly,
 )
@@ -37,6 +38,7 @@ __all__ = [
     "Outgoing",
     "Reply",
     "Senders",
+    "ChatType",
     "Text",
     "TextOnly",
 ]


### PR DESCRIPTION
`ChatType` filter wasn't exported to `telethon.events.filters`, and `sender` var name was not representing attribute type correctly