### PR TITLE
simplify type hints by using single Literal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,14 +39,14 @@ Creating a client
 
 .. code-block:: python
 
-    from telethon import TelegramClient, events, sync
+    from telethon import Client, events
 
     # These example values won't work. You must get your own api_id and
     # api_hash from https://my.telegram.org, under API Development.
     api_id = 12345
     api_hash = '0123456789abcdef0123456789abcdef'
 
-    async with TelegramClient('session_name', api_id, api_hash) as client:
+    async with Client('session_name', api_id, api_hash) as client:
         await client.interactive_login()
 
 

--- a/README.rst
+++ b/README.rst
@@ -37,9 +37,6 @@ Installing
 Creating a client
 -----------------
 
-
-Use ``python -m asyncio`` in order to run those examples
-
 .. code-block:: python
 
     from telethon import Client, events

--- a/README.rst
+++ b/README.rst
@@ -40,14 +40,20 @@ Creating a client
 .. code-block:: python
 
     from telethon import Client, events
+    import asyncio
 
     # These example values won't work. You must get your own api_id and
     # api_hash from https://my.telegram.org, under API Development.
     api_id = 12345
     api_hash = '0123456789abcdef0123456789abcdef'
 
-    async with Client('session_name', api_id, api_hash) as client:
-        await client.interactive_login()
+
+    async def main():
+        async with Client('session_name', api_id, api_hash) as client:
+            await client.interactive_login()
+
+
+    asyncio.run(main())
 
 
 Doing stuff

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,6 @@ Creating a client
     api_id = 12345
     api_hash = '0123456789abcdef0123456789abcdef'
 
-
     async with Client('session_name', api_id, api_hash) as client:
         await client.interactive_login()
 

--- a/README.rst
+++ b/README.rst
@@ -37,10 +37,12 @@ Installing
 Creating a client
 -----------------
 
+
+Use ``python -m asyncio`` in order to run those examples
+
 .. code-block:: python
 
     from telethon import Client, events
-    import asyncio
 
     # These example values won't work. You must get your own api_id and
     # api_hash from https://my.telegram.org, under API Development.
@@ -48,12 +50,8 @@ Creating a client
     api_hash = '0123456789abcdef0123456789abcdef'
 
 
-    async def main():
-        async with Client('session_name', api_id, api_hash) as client:
-            await client.interactive_login()
-
-
-    asyncio.run(main())
+    async with Client('session_name', api_id, api_hash) as client:
+        await client.interactive_login()
 
 
 Doing stuff

--- a/client/src/telethon/_impl/client/events/filters/messages.py
+++ b/client/src/telethon/_impl/client/events/filters/messages.py
@@ -159,14 +159,14 @@ class Media(Combinable):
     __slots__ = "_types"
 
     def __init__(
-        self, *types: Union[Literal["photo"], Literal["audio"], Literal["video"]]
+        self, *types: Literal["photo", "audio", "video"]
     ) -> None:
         self._types = types or None
 
     @property
     def types(
         self,
-    ) -> Tuple[Union[Literal["photo"], Literal["audio"], Literal["video"]], ...]:
+    ) -> Tuple[Literal["photo", "audio", "video"], ...]:
         """
         The media types being checked.
         """

--- a/client/src/telethon/_impl/session/message_box/defs.py
+++ b/client/src/telethon/_impl/session/message_box/defs.py
@@ -77,7 +77,7 @@ NO_UPDATES_TIMEOUT = 15 * 60
 
 ENTRY_ACCOUNT: Literal["ACCOUNT"] = "ACCOUNT"
 ENTRY_SECRET: Literal["SECRET"] = "SECRET"
-Entry = Union[Literal["ACCOUNT"], Literal["SECRET"], int]
+Entry = Union[Literal["ACCOUNT", "SECRET"], int]
 
 # Python's logging doesn't define a TRACE level. Pick halfway between DEBUG and NOTSET.
 # We don't define a name for this as libraries shouldn't do that though.


### PR DESCRIPTION
It is possible to use `Literal["a", "b", "c"]` instead of `Union[Literal["a"], Literal["b"], Literal["c"]]`
[Docs](https://docs.python.org/3/library/typing.html#typing.Literal)