### PR TITLE
simplify type hints by using single Literal

### DIFF
--- a/client/src/telethon/_impl/client/events/filters/messages.py
+++ b/client/src/telethon/_impl/client/events/filters/messages.py
@@ -159,14 +159,14 @@ class Media(Combinable):
     __slots__ = "_types"
 
     def __init__(
-        self, *types: Union[Literal["photo"], Literal["audio"], Literal["video"]]
+        self, *types: Literal["photo", "audio", "video"]
     ) -> None:
         self._types = types or None
 
     @property
     def types(
         self,
-    ) -> Tuple[Union[Literal["photo"], Literal["audio"], Literal["video"]], ...]:
+    ) -> Tuple[Literal["photo", "audio", "video"], ...]:
         """
         The media types being checked.
         """

--- a/client/src/telethon/_impl/session/message_box/defs.py
+++ b/client/src/telethon/_impl/session/message_box/defs.py
@@ -77,7 +77,7 @@ NO_UPDATES_TIMEOUT = 15 * 60
 
 ENTRY_ACCOUNT: Literal["ACCOUNT"] = "ACCOUNT"
 ENTRY_SECRET: Literal["SECRET"] = "SECRET"
-Entry = Union[Literal["ACCOUNT"], Literal["SECRET"], int]
+Entry = Union[Literal["ACCOUNT", "SECRET"], int]
 
 # Python's logging doesn't define a TRACE level. Pick halfway between DEBUG and NOTSET.
 # We don't define a name for this as libraries shouldn't do that though.


### PR DESCRIPTION
It is possible to use `Literal["a", "b", "c"]` instead of `Union[Literal["a"], Literal["b"], Literal["c"]]`
[Docs](https://docs.python.org/3/library/typing.html#typing.Literal)