### PR TITLE
rename client._shortcircuit_handlers and fix events.Continue in dispatch_next

### DIFF
--- a/client/src/telethon/_impl/client/client/client.py
+++ b/client/src/telethon/_impl/client/client/client.py
@@ -273,7 +273,7 @@ class Client:
         self._handlers: Dict[
             Type[Event], List[Tuple[Callable[[Any], Awaitable[Any]], Optional[Filter]]]
         ] = {}
-        self._shortcircuit_handlers = not check_all_handlers
+        self._check_all_handlers = check_all_handlers
 
         if self._session.user and self._config.catch_up and self._session.state:
             self._message_box.load(self._session.state)

--- a/client/src/telethon/_impl/client/client/updates.py
+++ b/client/src/telethon/_impl/client/client/updates.py
@@ -154,5 +154,5 @@ async def dispatch_next(client: Client) -> None:
             for handler, filter in handlers:
                 if not filter or filter(event):
                     ret = await handler(event)
-                    if ret is not Continue or client._shortcircuit_handlers:
+                    if not (ret is Continue or client._check_all_handlers):
                         return


### PR DESCRIPTION
Renamed `_shortcircuit_handlers` to `_check_all_handlers` for better consistency with client's parameter and fixed if statement for processing `events.Continue` and `_check_all_handlers` in `dispatch_next` function