### PR TITLE
[V2] added get_message method toButtonCallback,  abcs.Peer resolving to resolve_to_packed, __bool__ dunder method to Message

### DIFF
--- a/client/src/telethon/_impl/client/client/users.py
+++ b/client/src/telethon/_impl/client/client/users.py
@@ -172,6 +172,28 @@ async def resolve_to_packed(client: Client, chat: ChatLike) -> PackedChat:
         else:
             raise RuntimeError("unexpected case")
 
+    if isinstance(chat, abcs.Peer):
+        if isinstance(chat, types.PeerUser):
+            return PackedChat(
+                ty=PackedType.USER,
+                id=chat.user_id,
+                access_hash=0,
+            )
+        elif isinstance(chat, types.PeerChat):
+            return PackedChat(
+                ty=PackedType.CHAT,
+                id=chat.chat_id,
+                access_hash=0,
+            )
+        elif isinstance(chat, types.PeerChannel):
+            return PackedChat(
+                ty=PackedType.BROADCAST,
+                id=chat.channel_id,
+                access_hash=0,
+            )
+        else:
+            raise RuntimeError("unexpected case")
+
     if isinstance(chat, str):
         if chat.startswith("+"):
             resolved = await resolve_phone(client, chat)

--- a/client/src/telethon/_impl/client/client/users.py
+++ b/client/src/telethon/_impl/client/client/users.py
@@ -173,6 +173,9 @@ async def resolve_to_packed(client: Client, chat: Union[ChatLike, abcs.InputPeer
             raise RuntimeError("unexpected case")
 
     if isinstance(chat, abcs.Peer):
+        packed = client._chat_hashes.get(peer_id(chat))
+        if packed is not None:
+            return packed
         if isinstance(chat, types.PeerUser):
             return PackedChat(
                 ty=PackedType.USER,

--- a/client/src/telethon/_impl/client/client/users.py
+++ b/client/src/telethon/_impl/client/client/users.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional, Sequence
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
 from ...mtproto import RpcError
 from ...session import PackedChat, PackedType
@@ -117,7 +117,7 @@ async def get_chats(self: Client, chats: Sequence[ChatLike]) -> List[Chat]:
     ]
 
 
-async def resolve_to_packed(client: Client, chat: ChatLike) -> PackedChat:
+async def resolve_to_packed(client: Client, chat: Union[ChatLike, abcs.InputPeer, abcs.Peer]) -> PackedChat:
     if isinstance(chat, PackedChat):
         return chat
 

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -72,10 +72,9 @@ class ButtonCallback(Event):
 
     async def get_message(self) -> Optional[Message]:
         """
-        Returns the :class:`~telethon.types.Message` where the button click occurred,
-        or :data:`None` if the message couldn't be fetched
-        (for instance, if it's too old and no longer accessible to the bot).
+        Get the :class:`~telethon.types.Message` containing the button that was clicked.
 
+        If the message is too old and is no longer accessible, :data:`None` is returned instead.
         """
         peer_id_ = peer_id(self._raw.peer)
         peer = self._chat_map.get(peer_id_, None)

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Dict, Optional, Self
 
 from ...tl import abcs, functions, types
-from ..types import Chat
+from ..types import Chat, Message
 from .event import Event
+from ..types.chat import peer_id
 
 if TYPE_CHECKING:
     from ..client.client import Client
@@ -68,6 +69,22 @@ class ButtonCallback(Event):
                 cache_time=0,
             )
         )
+
+    async def get_message(self) -> Optional[Message]:
+        """
+        Returns the :class:`~telethon.types.Message` where the button click occurred,
+        or :data:`None` if the message couldn't be fetched
+        (for instance, if it's too old and no longer accessible to the bot).
+
+        """
+        peer_id_ = peer_id(self._raw.peer)
+        peer = self._chat_map.get(peer_id_, None)
+        if not peer:
+            peer = await self._client._resolve_to_packed(peer_id_)
+
+        message = (await self._client.get_messages_with_ids(chat=peer, message_ids=[self._raw.msg_id]))[0]
+
+        return message or None
 
 
 class InlineQuery(Event):

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -76,12 +76,12 @@ class ButtonCallback(Event):
 
         If the message is too old and is no longer accessible, :data:`None` is returned instead.
         """
-        peer_id_ = peer_id(self._raw.peer)
-        peer = self._chat_map.get(peer_id_, None)
-        if not peer:
-            peer = await self._client._resolve_to_packed(peer_id_)
+        pid = peer_id(self._raw.peer)
+        chat = self._chat_map.get(pid)
+        if not chat:
+            chat = await self._client._resolve_to_packed(pid)
 
-        message = (await self._client.get_messages_with_ids(chat=peer, message_ids=[self._raw.msg_id]))[0]
+        message = (await self._client.get_messages_with_ids(chat=chat, message_ids=[self._raw.msg_id]))[0]
 
         return message or None
 

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -6,6 +6,7 @@ from ...tl import abcs, functions, types
 from ..types import Chat, Message
 from .event import Event
 from ..types.chat import peer_id
+from ..client.messages import CherryPickedList
 
 if TYPE_CHECKING:
     from ..client.client import Client
@@ -76,12 +77,16 @@ class ButtonCallback(Event):
 
         If the message is too old and is no longer accessible, :data:`None` is returned instead.
         """
+
         pid = peer_id(self._raw.peer)
         chat = self._chat_map.get(pid)
         if not chat:
             chat = await self._client._resolve_to_packed(pid)
 
-        message = (await self._client.get_messages_with_ids(chat=chat, message_ids=[self._raw.msg_id]))[0]
+        lst = CherryPickedList(self._client, chat, [])
+        lst._ids.append(types.InputMessageCallbackQuery(id=self._raw.msg_id, query_id=self._raw.query_id))
+
+        message = (await lst)[0]
 
         return message or None
 

--- a/client/src/telethon/_impl/client/types/message.py
+++ b/client/src/telethon/_impl/client/types/message.py
@@ -45,6 +45,9 @@ class Message(metaclass=NoPublicConstructor):
 
     You can get a message from :class:`telethon.events.NewMessage`,
     or from methods such as :meth:`telethon.Client.get_messages`.
+
+    If the message is empty (like when it's not found using :meth:`telethon.Client.get_messages_with_ids`),
+    its ``__bool__`` method will yield :data:`False`.
     """
 
     def __init__(
@@ -481,6 +484,9 @@ class Message(metaclass=NoPublicConstructor):
             return not self._raw.noforwards
         else:
             return False
+
+    def __bool__(self):
+        return not isinstance(self._raw, types.MessageEmpty)
 
 
 def build_msg_map(

--- a/client/src/telethon/_impl/client/types/message.py
+++ b/client/src/telethon/_impl/client/types/message.py
@@ -55,7 +55,6 @@ class Message(metaclass=NoPublicConstructor):
         async for message in client.iter_messages(chat):
             if not message:
                 print('Found empty message with ID', message.id)
-    its ``__bool__`` method will yield :data:`False`.
     """
 
     def __init__(

--- a/client/src/telethon/_impl/client/types/message.py
+++ b/client/src/telethon/_impl/client/types/message.py
@@ -46,7 +46,15 @@ class Message(metaclass=NoPublicConstructor):
     You can get a message from :class:`telethon.events.NewMessage`,
     or from methods such as :meth:`telethon.Client.get_messages`.
 
-    If the message is empty (like when it's not found using :meth:`telethon.Client.get_messages_with_ids`),
+    Empty messages can occur very rarely when fetching the message history.
+    In these cases, only the :attr:`id` and :attr`peer` properties are guaranteed to be present.
+    To determine whether a message is empty, its truthy value can be checked via :meth:`object.__bool__`:
+
+    .. code-block:: python
+
+        async for message in client.iter_messages(chat):
+            if not message:
+                print('Found empty message with ID', message.id)
     its ``__bool__`` method will yield :data:`False`.
     """
 


### PR DESCRIPTION
[__bool__ dunder method was added to Message](https://github.com/LonamiWebs/Telethon/commit/3976988b333060b3fea4c94a7fcf0eb5e55a458e) in order to be able to check, if message is empty

[abcs.Peer resolving was added to resolve_to_packed](https://github.com/LonamiWebs/Telethon/commit/27d6cce8e2716058f097219c536d3e530bd5e8c3) in order to be able to resolve PackedChats by abcs.Peer, which are present in, for example, ButtonCallback's Event.

Regarding `get_message` itself, I assume `ButtonCallback._raw.msg_id` refers to **message id**, at least it is the case (tested) in:
- chat with user
- channel
- supergroup
- chat

However I may be missing something.