### PR TITLE
[V2] Added missing docstrings related to buttons, and added `buttons` to Message.edit

### DIFF
--- a/client/src/telethon/_impl/client/client/client.py
+++ b/client/src/telethon/_impl/client/client/client.py
@@ -585,6 +585,7 @@ class Client:
         markdown: Optional[str] = None,
         html: Optional[str] = None,
         link_preview: bool = False,
+        buttons: Optional[Union[List[btns.Button], List[List[btns.Button]]]] = None,
     ) -> Message:
         """
         Edit a message.
@@ -599,6 +600,10 @@ class Client:
         :param markdown: See :ref:`formatting`.
         :param html: See :ref:`formatting`.
         :param link_preview: See :ref:`formatting`.
+        :param buttons:
+            The buttons to use for the message.
+
+            Only bot accounts can send buttons.
 
         :return: The edited message.
 
@@ -624,6 +629,7 @@ class Client:
             markdown=markdown,
             html=html,
             link_preview=link_preview,
+            buttons=buttons
         )
 
     async def forward_messages(

--- a/client/src/telethon/_impl/client/client/messages.py
+++ b/client/src/telethon/_impl/client/client/messages.py
@@ -115,6 +115,7 @@ async def edit_message(
     markdown: Optional[str] = None,
     html: Optional[str] = None,
     link_preview: bool = False,
+    buttons: Optional[Union[List[btns.Button], List[List[btns.Button]]]] = None,
 ) -> Message:
     peer = (await self._resolve_to_packed(chat))._to_input_peer()
     message, entities = parse_message(
@@ -128,7 +129,7 @@ async def edit_message(
                 id=message_id,
                 message=message,
                 media=None,
-                reply_markup=None,
+                reply_markup=btns.build_keyboard(buttons),
                 entities=entities,
                 schedule_date=None,
             )

--- a/client/src/telethon/_impl/client/types/message.py
+++ b/client/src/telethon/_impl/client/types/message.py
@@ -331,6 +331,10 @@ class Message(metaclass=NoPublicConstructor):
         :param markdown: See :ref:`formatting`.
         :param html: See :ref:`formatting`.
         :param link_preview: See :meth:`~telethon.Client.send_message`.
+        :param buttons:
+            The buttons to use for the message.
+
+            Only bot accounts can send buttons.
         """
         return await self._client.send_message(
             self.chat,
@@ -357,6 +361,10 @@ class Message(metaclass=NoPublicConstructor):
         :param markdown: See :ref:`formatting`.
         :param html: See :ref:`formatting`.
         :param link_preview: See :meth:`~telethon.Client.send_message`.
+        :param buttons:
+            The buttons to use for the message.
+
+            Only bot accounts can send buttons.
         """
         return await self._client.send_message(
             self.chat,

--- a/client/src/telethon/_impl/client/types/message.py
+++ b/client/src/telethon/_impl/client/types/message.py
@@ -331,10 +331,7 @@ class Message(metaclass=NoPublicConstructor):
         :param markdown: See :ref:`formatting`.
         :param html: See :ref:`formatting`.
         :param link_preview: See :meth:`~telethon.Client.send_message`.
-        :param buttons:
-            The buttons to use for the message.
-
-            Only bot accounts can send buttons.
+        :param buttons: See :meth:`~telethon.Client.send_message`.
         """
         return await self._client.send_message(
             self.chat,
@@ -361,10 +358,7 @@ class Message(metaclass=NoPublicConstructor):
         :param markdown: See :ref:`formatting`.
         :param html: See :ref:`formatting`.
         :param link_preview: See :meth:`~telethon.Client.send_message`.
-        :param buttons:
-            The buttons to use for the message.
-
-            Only bot accounts can send buttons.
+        :param buttons: See :meth:`~telethon.Client.send_message`.
         """
         return await self._client.send_message(
             self.chat,
@@ -399,10 +393,7 @@ class Message(metaclass=NoPublicConstructor):
         :param markdown: See :ref:`formatting`.
         :param html: See :ref:`formatting`.
         :param link_preview: See :meth:`~telethon.Client.send_message`.
-        :param buttons:
-            The buttons to use for the message.
-
-            Only bot accounts can send buttons.
+        :param buttons: See :meth:`~telethon.Client.send_message`.
         """
         return await self._client.edit_message(
             self.chat,

--- a/client/src/telethon/_impl/client/types/message.py
+++ b/client/src/telethon/_impl/client/types/message.py
@@ -390,6 +390,7 @@ class Message(metaclass=NoPublicConstructor):
         markdown: Optional[str] = None,
         html: Optional[str] = None,
         link_preview: bool = False,
+        buttons: Optional[Union[List[Button], List[List[Button]]]] = None,
     ) -> Message:
         """
         Alias for :meth:`telethon.Client.edit_message`.
@@ -398,6 +399,10 @@ class Message(metaclass=NoPublicConstructor):
         :param markdown: See :ref:`formatting`.
         :param html: See :ref:`formatting`.
         :param link_preview: See :meth:`~telethon.Client.send_message`.
+        :param buttons:
+            The buttons to use for the message.
+
+            Only bot accounts can send buttons.
         """
         return await self._client.edit_message(
             self.chat,
@@ -406,6 +411,7 @@ class Message(metaclass=NoPublicConstructor):
             markdown=markdown,
             html=html,
             link_preview=link_preview,
+            buttons=buttons,
         )
 
     async def forward(self, target: ChatLike) -> Message:


### PR DESCRIPTION
Docstrings, explaining buttons, were copied from send_message, so I hope that's OK.

buttons editing is often used with bot menus workflows, involving callback buttons.

Note: In telethon v1 `build_reply_markup` [function](https://github.com/LonamiWebs/Telethon/blob/308f8e8bf8ba18c3d8c344b242a9a063e2e3fe9a/telethon/client/buttons.py#L9) would return `None`, but in v2 leaving buttons as `None` will result in an empty markup in `build_keyboard` [function](https://github.com/LonamiWebs/Telethon/blob/v2/client/src/telethon/_impl/client/types/buttons/__init__.py#L26) (despite it having `Optional[abcs.ReplyMarkup]` return type), instead of `None`, not sure if it's intended, and how does it affect editing.

P.S. I have no idea why is there invalid character in 2nd commit name
