### PR TITLE
[V2] add inlinecallback to buttoncallback event

### DIFF
--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -85,7 +85,6 @@ class ButtonCallback(Event):
         if isinstance(self._raw, types.UpdateInlineBotCallbackQuery):
             # for that type of update, the msg_id and owner_id are present, however bot is not guaranteed
             # to have "access" to the owner_id.
-            owner_id = None
             if isinstance(self._raw.msg_id, types.InputBotInlineMessageId):
                 # telegram used to pack msg_id and peer_id into InputBotInlineMessageId.id
                 # I assume this is for the chats with IDs, fitting into 32-bit integer.

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -50,7 +50,7 @@ class ButtonCallback(Event):
     def chat(self) -> Optional[Chat]:
         """
         The :term:`chat` when the message was sent.
-        Only available if the event was triggered by a button under usual message, not an inline one.
+        Only available if the event was triggered by a button under a usual message, not an inline one.
         """
         if isinstance(self._raw, types.UpdateInlineBotCallbackQuery):
             return None

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -49,8 +49,9 @@ class ButtonCallback(Event):
     @property
     def chat(self) -> Optional[Chat]:
         """
-        The :term:`chat` when the message was sent.
-        Only available if the event was triggered by a button under a usual message, not an inline one.
+        The :term:`chat` where the button was clicked.
+
+        This will be :data:`None` if the message with the button was sent from a user's inline query.
         """
         if isinstance(self._raw, types.UpdateInlineBotCallbackQuery):
             return None

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -78,7 +78,7 @@ class ButtonCallback(Event):
         """
         The :term:`chat` where the button was clicked.
 
-        This will be :data:`None` if the message with the button was sent from a user's inline query, except in channel.
+        This may be :data:`None` if :data:`via_inline` is :data:`True`, as the bot might not be part of the chat.
         """
         if isinstance(self._raw, types.UpdateInlineBotCallbackQuery):
             owner_id = None

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -56,9 +56,8 @@ class ButtonCallback(Event):
         """
         Whether the button was clicked in an inline message.
 
-        If it was, most likely bot is not in chat, and the :meth:`chat` property will return :data:`None`,
-        same for :meth:`get_message` method, however editing the message, using :meth:`message_id` property
-        and :meth:`answer` method will work.
+        If it was, it might indicate that the bot is not in chat.
+        If this is the case, both the :meth:`chat` and :meth:`get_message` will return :data:`None`.
         """
         return isinstance(self._raw, types.UpdateInlineBotCallbackQuery)
 

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import struct
 from typing import TYPE_CHECKING, Dict, Optional, Self, Union
 
 from ...tl import abcs, functions, types
-from ..types import Chat, Message
+from ..types import Chat, Message, Channel
 from .event import Event
 from ..types.chat import peer_id
 from ..client.messages import CherryPickedList
@@ -34,7 +35,10 @@ class ButtonCallback(Event):
         cls, client: Client, update: abcs.Update, chat_map: Dict[int, Chat]
     ) -> Optional[Self]:
         if (
-            isinstance(update, (types.UpdateBotCallbackQuery, types.UpdateInlineBotCallbackQuery))
+            isinstance(
+                update,
+                (types.UpdateBotCallbackQuery, types.UpdateInlineBotCallbackQuery),
+            )
             and update.data is not None
         ):
             return cls._create(client, update, chat_map)
@@ -51,10 +55,41 @@ class ButtonCallback(Event):
         """
         The :term:`chat` where the button was clicked.
 
-        This will be :data:`None` if the message with the button was sent from a user's inline query.
+        This will be :data:`None` if the message with the button was sent from a user's inline query, except in channel.
         """
         if isinstance(self._raw, types.UpdateInlineBotCallbackQuery):
-            return None
+            owner_id = None
+            if isinstance(self._raw.msg_id, types.InputBotInlineMessageId):
+                _, owner_id = struct.unpack("<ii", struct.pack("<q", self._raw.msg_id.id))
+            elif isinstance(self._raw.msg_id, types.InputBotInlineMessageId64):
+                _ = self._raw.msg_id.id
+                owner_id = self._raw.msg_id.owner_id
+
+            if owner_id is None:
+                return None
+
+            if owner_id > 0:
+                # We can't know if it's really a chat with user, or an ID of the user who issued the inline query.
+                # So it's better to return None, then to return wrong chat.
+                return None
+
+            owner_id = -owner_id
+
+            access_hash = 0
+            packed = self.client._chat_hashes.get(owner_id)
+            if packed:
+                access_hash = packed.access_hash
+
+            return Channel._from_raw(
+                types.ChannelForbidden(
+                    broadcast=True,
+                    megagroup=False,
+                    id=owner_id,
+                    access_hash=access_hash,
+                    title="",
+                    until_date=None,
+                )
+            )
         return self._chat_map.get(peer_id(self._raw.peer))
 
     async def answer(
@@ -91,20 +126,57 @@ class ButtonCallback(Event):
 
         If the message is inline, or too old and is no longer accessible, :data:`None` is returned instead.
         """
+        chat = None
+
         if isinstance(self._raw, types.UpdateInlineBotCallbackQuery):
-            return None
+            # for that type of update, the msg_id and owner_id are present, however bot is not guaranteed
+            # to have "access" to the owner_id.
+            if isinstance(self._raw.msg_id, types.InputBotInlineMessageId):
+                # telegram used to pack msg_id and peer_id into InputBotInlineMessageId.id
+                # I assume this is for the chats with IDs, fitting into 32-bit integer.
+                msg_id, owner_id = struct.unpack(
+                    "<ii", struct.pack("<q", self._raw.msg_id.id)
+                )
+            elif isinstance(self._raw.msg_id, types.InputBotInlineMessageId64):
+                msg_id = self._raw.msg_id.id
+                owner_id = self._raw.msg_id.owner_id
+            else:
+                return None
 
-        pid = peer_id(self._raw.peer)
-        chat = self._chat_map.get(pid)
-        if not chat:
-            chat = await self._client._resolve_to_packed(pid)
+            msg = types.InputMessageCallbackQuery(
+                id=msg_id, query_id=self._raw.query_id
+            )
+            if owner_id < 0:
+                # that means update's owner_id actually is the peer (channel), where the button was clicked.
+                # if it was positive, it'd be the user who issued the inline query.
+                try:
+                    chat = await self._client._resolve_to_packed(-owner_id)
+                except ValueError:
+                    pass
+        else:
+            pid = peer_id(self._raw.peer)
+            msg = types.InputMessageCallbackQuery(
+                id=self._raw.msg_id, query_id=self._raw.query_id
+            )
 
-        lst = CherryPickedList(self._client, chat, [])
-        lst._ids.append(types.InputMessageCallbackQuery(id=self._raw.msg_id, query_id=self._raw.query_id))
+            chat = self._chat_map.get(pid)
+            if not chat:
+                chat = await self._client._resolve_to_packed(pid)
 
-        message = (await lst)[0]
+        if chat:
+            lst = CherryPickedList(self._client, chat, [])
+            lst._ids.append(msg)
 
-        return message or None
+            res = await lst
+            if res:
+                return res[0] or None
+
+        res = await self._client(
+            functions.messages.get_messages(
+                id=[msg],
+            )
+        )
+        return res.messages[0] if res.messages else None
 
 
 class InlineQuery(Event):

--- a/client/src/telethon/_impl/client/events/queries.py
+++ b/client/src/telethon/_impl/client/events/queries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import struct
+import typing
 from typing import TYPE_CHECKING, Dict, Optional, Self, Union
 
 from ...tl import abcs, functions, types
@@ -49,6 +50,29 @@ class ButtonCallback(Event):
     def data(self) -> bytes:
         assert self._raw.data is not None
         return self._raw.data
+
+    @property
+    def via_inline(self) -> bool:
+        """
+        Whether the button was clicked in an inline message.
+
+        If it was, most likely bot is not in chat, and the :meth:`chat` property will return :data:`None`,
+        same for :meth:`get_message` method, however editing the message, using :meth:`message_id` property
+        and :meth:`answer` method will work.
+        """
+        return isinstance(self._raw, types.UpdateInlineBotCallbackQuery)
+
+    @property
+    def message_id(self) -> typing.Union[int, abcs.InputBotInlineMessageId]:
+        """
+        The ID of the message containing the button that was clicked.
+        
+        If the message is inline, :class:`abcs.InputBotInlineMessageId` will be returned.
+        You can use it in :meth:`~telethon._tl.functions.messages.edit_inline_bot_message` to edit the message.
+
+        Else, usual message ID will be returned.
+        """
+        return self._raw.msg_id
 
     @property
     def chat(self) -> Optional[Chat]:

--- a/client/src/telethon/_impl/client/types/chat/channel.py
+++ b/client/src/telethon/_impl/client/types/chat/channel.py
@@ -54,11 +54,12 @@ class Channel(Chat, metaclass=NoPublicConstructor):
         if self._raw.access_hash is None:
             return None
         else:
-            ty = PackedType.BROADCAST
             if getattr(self._raw, "megagroup", False):
                 ty = PackedType.MEGAGROUP
             elif getattr(self._raw, "gigagroup", False):
                 ty = PackedType.GIGAGROUP
+            else:
+                ty = PackedType.BROADCAST
             return PackedChat(
                 ty=ty,
                 id=self._raw.id,

--- a/client/src/telethon/_impl/client/types/chat/channel.py
+++ b/client/src/telethon/_impl/client/types/chat/channel.py
@@ -54,10 +54,13 @@ class Channel(Chat, metaclass=NoPublicConstructor):
         if self._raw.access_hash is None:
             return None
         else:
+            ty = PackedType.BROADCAST
+            if getattr(self._raw, "megagroup", False):
+                ty = PackedType.MEGAGROUP
+            elif getattr(self._raw, "gigagroup", False):
+                ty = PackedType.GIGAGROUP
             return PackedChat(
-                ty=PackedType.GIGAGROUP
-                if getattr(self._raw, "gigagroup", False)
-                else PackedType.BROADCAST,
+                ty=ty,
                 id=self._raw.id,
                 access_hash=self._raw.access_hash,
             )

--- a/client/src/telethon/_impl/client/types/chat/group.py
+++ b/client/src/telethon/_impl/client/types/chat/group.py
@@ -72,7 +72,7 @@ class Group(Chat, metaclass=NoPublicConstructor):
             return None
         else:
             return PackedChat(
-                ty=PackedType.MEGAGROUP,
+                ty=PackedType.GIGAGROUP if getattr(self._raw, "gigagroup", False) else PackedType.MEGAGROUP,
                 id=self._raw.id,
                 access_hash=self._raw.access_hash,
             )

--- a/client/src/telethon/_impl/client/types/dialog.py
+++ b/client/src/telethon/_impl/client/types/dialog.py
@@ -49,7 +49,7 @@ class Dialog(metaclass=NoPublicConstructor):
     @property
     def chat(self) -> Chat:
         """
-        The chat where messages are sent in this dialog.
+        The :term:`chat` where messages are sent in this dialog.
         """
         return self._chat_map[peer_id(self._raw.peer)]
 

--- a/client/src/telethon/_impl/client/types/draft.py
+++ b/client/src/telethon/_impl/client/types/draft.py
@@ -56,7 +56,7 @@ class Draft(metaclass=NoPublicConstructor):
     @property
     def chat(self) -> Chat:
         """
-        The chat where the draft is saved.
+        The :term:`chat` where the draft is saved.
 
         This is also the chat where the message will be sent to by :meth:`send`.
         """


### PR DESCRIPTION
Allow `ButtonCallback` event to handle `UpdateInlineBotCallbackQuery`, add `chat` property to it