### PR TITLE
Fix ordering of closing tags of sequential entities

### DIFF
--- a/telethon/extensions/html.py
+++ b/telethon/extensions/html.py
@@ -175,7 +175,7 @@ def unparse(text: str, entities: Iterable[TypeMessageEntity]) -> str:
             if callable(delimiter):
                 delimiter = delimiter(entity, text[s:e])
             insert_at.append((s, i, delimiter[0]))
-            insert_at.append((e, len(entities) - i, delimiter[1]))
+            insert_at.append((e, -i, delimiter[1]))
 
     insert_at.sort(key=lambda t: (t[0], t[1]))
     next_escape_bound = len(text)

--- a/telethon/extensions/html.py
+++ b/telethon/extensions/html.py
@@ -124,6 +124,8 @@ def parse(html: str) -> Tuple[str, List[TypeMessageEntity]]:
     parser = HTMLToTelegramParser()
     parser.feed(add_surrogate(html))
     text = strip_text(parser.text, parser.entities)
+    parser.entities.reverse()
+    parser.entities.sort(key=lambda entity: entity.offset)
     return del_surrogate(text), parser.entities
 
 

--- a/telethon/extensions/markdown.py
+++ b/telethon/extensions/markdown.py
@@ -170,7 +170,7 @@ def unparse(text, entities, delimiters=None, url_fmt=None):
         delimiter = delimiters.get(type(entity), None)
         if delimiter:
             insert_at.append((s, i, delimiter))
-            insert_at.append((e, len(entities) - i, delimiter))
+            insert_at.append((e, -i, delimiter))
         else:
             url = None
             if isinstance(entity, MessageEntityTextUrl):
@@ -179,7 +179,7 @@ def unparse(text, entities, delimiters=None, url_fmt=None):
                 url = 'tg://user?id={}'.format(entity.user_id)
             if url:
                 insert_at.append((s, i, '['))
-                insert_at.append((e, len(entities) - i, ']({})'.format(url)))
+                insert_at.append((e, -i, ']({})'.format(url)))
 
     insert_at.sort(key=lambda t: (t[0], t[1]))
     while insert_at:

--- a/tests/telethon/extensions/test_html.py
+++ b/tests/telethon/extensions/test_html.py
@@ -53,6 +53,22 @@ def test_entities_together():
     assert text == original
 
 
+def test_nested_entities():
+    """
+    Test that an entity nested inside another one behaves well.
+    """
+    original = '<a href="https://example.com"><strong>Example</strong></a>'
+    original_entities = [MessageEntityTextUrl(0, 7, url='https://example.com'), MessageEntityBold(0, 7)]
+    stripped = 'Example'
+
+    text, entities = html.parse(original)
+    assert text == stripped
+    assert entities == original_entities
+
+    text = html.unparse(text, entities)
+    assert text == original
+
+
 def test_offset_at_emoji():
     """
     Tests that an entity starting at a emoji preserves the emoji.

--- a/tests/telethon/extensions/test_markdown.py
+++ b/tests/telethon/extensions/test_markdown.py
@@ -53,6 +53,21 @@ def test_entities_together():
     assert text == original
 
 
+def test_nested_entities():
+    """
+    Test that an entity nested inside another one behaves well.
+    """
+    original = '**[Example](https://example.com)**'
+    stripped = 'Example'
+
+    text, entities = markdown.parse(original)
+    assert text == stripped
+    assert entities == [MessageEntityBold(0, 7), MessageEntityTextUrl(0, 7, url='https://example.com')]
+
+    text = markdown.unparse(text, entities)
+    assert text == original
+
+
 def test_offset_at_emoji():
     """
     Tests that an entity starting at a emoji preserves the emoji.


### PR DESCRIPTION
#4201 breaks the parsing of sequential entities because it puts the closing tag after the next opening tag:

```python
text, entities = html.parse('<strong>⚙️</strong><em>Settings</em>')
html_text = html.unparse(text, entities)
print(html_text)
# <strong>⚙️<em></strong>Settings</em>
```

This is a superficial issue with HTML, but actually breaks in Markdown and ends up as `**⚙️__**Settings__`

I fixed this behaviour by prioritizing closing tags that occur at the same position as opening tags, so that the `</strong>` is inserted before the `<em>`. 

---

I added tests to check that nested entities still behave correctly, however the HTML test fails because the HTML parser swaps the order of nested entities (since it recognizes an entity when seeing the closing tag):

```python
text, entities = html.parse('<em><strong>hello</strong></em>')
print(entities)
# [<telethon.tl.types.MessageEntityBold object at 0x7f82cfba0f50>, <telethon.tl.types.MessageEntityTextUrl object at 0x7f82cfba0f10>]
# bold entity occurs before the italic one, because it was closed first
```

This also means that repeatedly parsing and unparsing nested entities swaps their ordering:

```python
text, entities = html.parse('<em><strong>hello</strong></em>')
html_text = html.unparse(text, entities)
print(html_text)
# tags have been swapped:
# <strong><em>hello</em></strong>

text, entities = html.parse(html_text)
html_text = html.unparse(text, entities)
print(html_text)
# tags have been swapped again:
# <em><strong>hello</strong></em>
```

(this causes the test to fail because parsing and unparsing gives a different output)

I added a commit to fix it, but I am not sure if it's acceptable. I think it could be fixed inside the parsing code directly, instead of sorting the entities afterwards.