### PR TITLE
Docs update: s/get_input_user/get_input_sender

### DIFF
--- a/readthedocs/concepts/entities.rst
+++ b/readthedocs/concepts/entities.rst
@@ -268,7 +268,7 @@ That means you can do this:
 .. code-block:: python
 
     message.user_id
-    await message.get_input_user()
+    await message.get_input_sender()
     message.user
     # ...etc
 


### PR DESCRIPTION
`Message` inherits from `SenderGetter` (as mentioned a couple lines above this change). 

SenderGetter implements `get_input_sender`, not `get_input_user`.