### PR TITLE
[V1] Fix restriction_reason type

### DIFF
--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -205,7 +205,7 @@ class Message(ChatGetter, SenderGetter, TLObject):
             noforwards: Optional[bool] = None,
             invert_media: Optional[bool] = None,
             reactions: Optional[types.TypeMessageReactions] = None,
-            restriction_reason: Optional[types.TypeRestrictionReason] = None,
+            restriction_reason: Optional[List[types.TypeRestrictionReason]] = None,
             forwards: Optional[int] = None,
             replies: Optional[types.TypeMessageReplies] = None,
 


### PR DESCRIPTION
Fix restriction_reason type. A list is specified [here](https://github.com/LonamiWebs/Telethon/blob/2082a0e4deb968007c1b0021909de7bc7014a01f/telethon/tl/custom/message.py#L153), but the [argument](https://github.com/LonamiWebs/Telethon/blob/2082a0e4deb968007c1b0021909de7bc7014a01f/telethon/tl/custom/message.py#L208) is not a list