### PR TITLE
Bugfix: Update within_surrogate helper function to properly parse all surrogates

### DIFF
--- a/telethon/helpers.py
+++ b/telethon/helpers.py
@@ -58,7 +58,7 @@ def within_surrogate(text, index, *, length=None):
 
     return (
             1 < index < len(text) and  # in bounds
-            '\ud800' <= text[index - 1] <= '\udfff' and  # previous is
+            '\ud800' <= text[index - 1] <= '\udbff' and  # previous is
             '\ud800' <= text[index] <= '\udfff'  # current is
     )
 


### PR DESCRIPTION
I noticed this bug in TelethonChat where someone mentioned using the CustomMarkdown option from the wiki. I am using the same solution and verified that I was able to reproduce the issue.

@disk6969 was kind enough to provide a solution and the logic behind it. I created this PR so that this issue is fixed in upstream too


![image](https://github.com/LonamiWebs/Telethon/assets/45726744/07e8bb38-0930-469c-848d-f45224c6ed3e)
