### PR TITLE
Fixed bug with supplying custom class for parse_mode

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -756,7 +756,10 @@ def sanitize_parse_mode(mode):
     if not mode:
         return None
 
-    if callable(mode):
+    if (all(hasattr(mode, x) for x in ('parse', 'unparse'))
+          and all(callable(x) for x in (mode.parse, mode.unparse))):
+        return mode
+    elif callable(mode):
         class CustomMode:
             @staticmethod
             def unparse(text, entities):
@@ -764,9 +767,6 @@ def sanitize_parse_mode(mode):
 
         CustomMode.parse = mode
         return CustomMode
-    elif (all(hasattr(mode, x) for x in ('parse', 'unparse'))
-          and all(callable(x) for x in (mode.parse, mode.unparse))):
-        return mode
     elif isinstance(mode, str):
         try:
             return {


### PR DESCRIPTION
In the previous version, the check for if the supplied mode in callable was first, but since classes(an object that can have a parse and unparse method) are also callable in python, it triggers the first "if" clause and overwrite the object with it's own new class without the unparse method.

After changing the 2nd "if" clause with the first "if" clause, it first check for an object with parse and unparse attribute. And if is exists, then simply return it.
And the 1st check's functionality(to check if user passed a function) still works cause a function cannot have those attributes and so it will trigger the "elif" clause which, yes is unchanged and will still do it's job of converting parse function to an object with parse and unparse attribute.

And because of some wierd issues, we can't also pass in an instance of the custom markdown too, making this change a must for custom markdowns to work