### PR TITLE
add custom secret support

### DIFF
--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -1,4 +1,3 @@
-import binascii
 import asyncio
 import hashlib
 import base64
@@ -140,11 +139,8 @@ class TcpMTProxy(ObfuscatedConnection):
         try:
             secret_bytes = bytes.fromhex(secret)
         except ValueError:
-            try:
-                secret_bytes = base64.b64decode(secret.encode())
-            except binascii.Error:
-                secret = secret + "=="
-                secret_bytes = base64.b64decode(secret.encode())
+            secret = secret + '=' * (-len(s) % 4)
+            secret_bytes = base64.b64decode(secret.encode())
 
         return secret_bytes[:16]  # Remove the domain from the secret (until domain support is added)
 

--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -134,7 +134,7 @@ class TcpMTProxy(ObfuscatedConnection):
 
     @staticmethod
     def normilize_secret(secret):
-        if secret[:2] in ["ee","dd"]: # Remove extra bytes
+        if secret[:2] in ("ee", "dd"):  # Remove extra bytes
             secret = secret[2:]
 
         try:

--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -139,7 +139,7 @@ class TcpMTProxy(ObfuscatedConnection):
         try:
             secret_bytes = bytes.fromhex(secret)
         except ValueError:
-            secret = secret + '=' * (-len(s) % 4)
+            secret = secret + '=' * (-len(secret) % 4)
             secret_bytes = base64.b64decode(secret.encode())
 
         return secret_bytes[:16]  # Remove the domain from the secret (until domain support is added)

--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -100,7 +100,7 @@ class TcpMTProxy(ObfuscatedConnection):
     def __init__(self, ip, port, dc_id, *, loggers, proxy=None, local_addr=None):
         # connect to proxy's host and port instead of telegram's ones
         proxy_host, proxy_port = self.address_info(proxy)
-        self._secret = TcpMTProxy.normilize_secret(proxy[2])
+        self._secret = self.normalize_secret(proxy[2])
         super().__init__(
             proxy_host, proxy_port, dc_id, loggers=loggers)
 

--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -139,7 +139,7 @@ class TcpMTProxy(ObfuscatedConnection):
 
         try:
             secret_bytes = bytes.fromhex(secret)
-        except:
+        except ValueError:
             try:
                 secret_bytes = base64.b64decode(secret.encode())
             except binascii.Error:

--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -146,7 +146,7 @@ class TcpMTProxy(ObfuscatedConnection):
                 secret = secret + "=="
                 secret_bytes = base64.b64decode(secret.encode())
 
-        return secret_bytes[:16] # Remove the domain from the secret (until domain support is added)
+        return secret_bytes[:16]  # Remove the domain from the secret (until domain support is added)
 
 class ConnectionTcpMTProxyAbridged(TcpMTProxy):
     """

--- a/telethon/network/connection/tcpmtproxy.py
+++ b/telethon/network/connection/tcpmtproxy.py
@@ -132,7 +132,7 @@ class TcpMTProxy(ObfuscatedConnection):
         return proxy_info[:2]
 
     @staticmethod
-    def normilize_secret(secret):
+    def normalize_secret(secret):
         if secret[:2] in ("ee", "dd"):  # Remove extra bytes
             secret = secret[2:]
 


### PR DESCRIPTION
How does it work?                                                              
 * Telegram can decode base64 and hexadecimal secrets. Proxy makers convert the 
   hexadecimal secret to base64, and both formats are essentially the same. In
   some proxies, secrets may include fake TLS domains. However, this specific 
   method does not handle fake TLS domain.