### PR TITLE
[V1] minor: Update phone and pass type in start()

### DIFF
--- a/telethon/client/auth.py
+++ b/telethon/client/auth.py
@@ -19,8 +19,8 @@ class AuthMethods:
 
     def start(
             self: 'TelegramClient',
-            phone: typing.Callable[[], str] = lambda: input('Please enter your phone (or bot token): '),
-            password: typing.Callable[[], str] = lambda: getpass.getpass('Please enter your password: '),
+            phone: typing.Callable[[], str] | str = lambda: input('Please enter your phone (or bot token): '),
+            password: typing.Callable[[], str] | str = lambda: getpass.getpass('Please enter your password: '),
             *,
             bot_token: str = None,
             force_sms: bool = False,


### PR DESCRIPTION
This PR updates the type signature of `AuthMethods.start()`'s `phone` and `password` arguments to allow passing strings instead of a callable that returns strings.

The method supports strings and callables that return strings, so this minor update just makes the type match reality. This is even what the docs say:

```
        Arguments
            phone (`str` | `int` | `callable`):
                The phone (or callable without arguments to get it)
                to which the code will be sent. If a bot-token-like
                string is given, it will be used as such instead.
                The argument may be a coroutine.
```

Though the docs say you can pass an `int`. I didn't want to go overboard.

I know this PR may seem pedantic but I wanted my linter to stop complaining without adding an explicit ignore comment to my code. I can't be the only one 😄 