### PR TITLE
fixing union for python <= 3.9

### DIFF
--- a/telethon/client/auth.py
+++ b/telethon/client/auth.py
@@ -19,8 +19,8 @@ class AuthMethods:
 
     def start(
             self: 'TelegramClient',
-            phone: typing.Callable[[], str] | str = lambda: input('Please enter your phone (or bot token): '),
-            password: typing.Callable[[], str] | str = lambda: getpass.getpass('Please enter your password: '),
+            phone: typing.Union[typing.Callable[[], str], str] = lambda: input('Please enter your phone (or bot token): '),
+            password: typing.Union[typing.Callable[[], str], str] = lambda: getpass.getpass('Please enter your password: '),
             *,
             bot_token: str = None,
             force_sms: bool = False,


### PR DESCRIPTION
<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->
python version 3.9 or below doesn't support the new `|`  union operator , leading to  failures while initializing the client. making changes so as to use the traditional `typing.Union` 