### PR TITLE
fix UserMethods get_entity type hints

### DIFF
--- a/telethon/client/users.py
+++ b/telethon/client/users.py
@@ -222,7 +222,7 @@ class UserMethods:
 
     async def get_entity(
             self: 'TelegramClient',
-            entity: 'hints.EntitiesLike') -> 'hints.Entity':
+            entity: 'hints.EntitiesLike') -> typing.Union['hints.Entity', typing.List['hints.Entity']]:
         """
         Turns the given entity into a valid Telegram :tl:`User`, :tl:`Chat`
         or :tl:`Channel`. You can also pass a list or iterable of entities,


### PR DESCRIPTION
Fixed type hints for the `get_entity` method in the `UserMethods` class to include a list of Entity objects