### PR TITLE
Expand HTML tag checks for existing entities

### DIFF
--- a/telethon/extensions/html.py
+++ b/telethon/extensions/html.py
@@ -14,7 +14,7 @@ from ..tl.types import (
     MessageEntityPre, MessageEntityEmail, MessageEntityUrl,
     MessageEntityTextUrl, MessageEntityMentionName,
     MessageEntityUnderline, MessageEntityStrike, MessageEntityBlockquote,
-    TypeMessageEntity
+    MessageEntitySpoiler, TypeMessageEntity
 )
 
 
@@ -40,8 +40,10 @@ class HTMLToTelegramParser(HTMLParser):
             EntityType = MessageEntityItalic
         elif tag == 'u':
             EntityType = MessageEntityUnderline
-        elif tag == 'del' or tag == 's':
+        elif tag in ('del', 's', 'strike'):
             EntityType = MessageEntityStrike
+        elif tag == 'details':
+            EntityType = MessageEntitySpoiler
         elif tag == 'blockquote':
             EntityType = MessageEntityBlockquote
         elif tag == 'code':
@@ -132,6 +134,7 @@ def parse(html: str) -> Tuple[str, List[TypeMessageEntity]]:
 ENTITY_TO_FORMATTER = {
     MessageEntityBold: ('<strong>', '</strong>'),
     MessageEntityItalic: ('<em>', '</em>'),
+    MessageEntitySpoiler: ('<details>', '</details>'),
     MessageEntityCode: ('<code>', '</code>'),
     MessageEntityUnderline: ('<u>', '</u>'),
     MessageEntityStrike: ('<del>', '</del>'),


### PR DESCRIPTION
Just added the necessary tag checks for ALREADY existing `MessageEntitySpoiler` entity and expanded checking for `MessageEntityStrike` by adding one conservative `strike` tag