### PR TITLE
Add Button.web_view()

### DIFF
--- a/telethon/tl/custom/button.py
+++ b/telethon/tl/custom/button.py
@@ -307,3 +307,14 @@ class Button:
         documentation for more information on using games.
         """
         return types.KeyboardButtonGame(text)
+
+    @staticmethod
+    def web_view(text, url=None):
+        """
+        Creates a new inline button to open the desired URL in a WebView.
+        If no `url` is given, the `text` will be used as the URL instead.
+        You cannot detect that the user clicked this button directly.
+        When the user clicks this button, the URL will open in the Telegram
+        app's WebView directly.
+        """
+        return types.KeyboardButtonWebView(text, url or text)


### PR DESCRIPTION
In theory, it should open links inside the telegram app rather than opening another browser.

Please advise if this is not necessary

<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->
