### PR TITLE
Removed Problematic Line

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -1254,8 +1254,7 @@ def pack_bot_file_id(file):
 
         if not size:
             return None
-
-        size = size.location
+    
         return _encode_telegram_base64(_rle_encode(struct.pack(
             '<iiqqqqib', 2, file.dc_id, file.id, file.access_hash,
             size.volume_id, 0, size.local_id, 2  # 0 = old `secret`


### PR DESCRIPTION
The line size = size.location was removed because it was causing an error when size did not have a location attribute.

<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->
