### PR TITLE
edit parsers

### DIFF
--- a/telethon/extensions/html.py
+++ b/telethon/extensions/html.py
@@ -1,11 +1,10 @@
 """
 Simple HTML -> Telegram entity parser.
 """
-import struct
 from collections import deque
 from html import escape
 from html.parser import HTMLParser
-from typing import Iterable, Optional, Tuple, List
+from typing import Iterable, Tuple, List
 
 from ..helpers import add_surrogate, del_surrogate, within_surrogate, strip_text
 from ..tl import TLObject
@@ -14,7 +13,7 @@ from ..tl.types import (
     MessageEntityPre, MessageEntityEmail, MessageEntityUrl,
     MessageEntityTextUrl, MessageEntityMentionName,
     MessageEntityUnderline, MessageEntityStrike, MessageEntityBlockquote,
-    TypeMessageEntity
+    TypeMessageEntity, MessageEntitySpoiler
 )
 
 
@@ -42,6 +41,8 @@ class HTMLToTelegramParser(HTMLParser):
             EntityType = MessageEntityUnderline
         elif tag == 'del' or tag == 's':
             EntityType = MessageEntityStrike
+        elif tag == 'spoiler':
+            EntityType = MessageEntitySpoiler
         elif tag == 'blockquote':
             EntityType = MessageEntityBlockquote
         elif tag == 'code':

--- a/telethon/extensions/markdown.py
+++ b/telethon/extensions/markdown.py
@@ -11,7 +11,7 @@ from ..tl import TLObject
 from ..tl.types import (
     MessageEntityBold, MessageEntityItalic, MessageEntityCode,
     MessageEntityPre, MessageEntityTextUrl, MessageEntityMentionName,
-    MessageEntityStrike
+    MessageEntityStrike, MessageEntitySpoiler
 )
 
 DEFAULT_DELIMITERS = {
@@ -19,7 +19,8 @@ DEFAULT_DELIMITERS = {
     '__': MessageEntityItalic,
     '~~': MessageEntityStrike,
     '`': MessageEntityCode,
-    '```': MessageEntityPre
+    '```': MessageEntityPre,
+    '||': MessageEntitySpoiler
 }
 
 DEFAULT_URL_RE = re.compile(r'\[([^\]]+)\]\(([^)]+)\)')


### PR DESCRIPTION
**1- Remove unused imports from [telethon/extensions/html.py](https://github.com/LonamiWebs/Telethon/blob/v1/telethon/extensions/html.py).**

2- Add `spoiler` tag to **html** parser, and `"||" ` syntax for markdown parser, so now we can send spoiler text totally like [Telegram Bot API](https://core.telegram.org/bots/api#markdownv2-style) instead of use [this way.](https://github.com/LonamiWebs/Telethon/wiki/Sending-more-than-just-messages#sending-spoilers-and-custom-emoji)

### Example:
```python
await client.send_message(
    "lonami",
    "<spoiler>This is a spoiler text</spoiler>",
    parse_mode="html"
)
```
or
```python
await client.send_message(
    "lonami",
    "||This is a spoiler text||",
    parse_mode="markdown"
)
```