### PR TITLE
update parsers

### DIFF
--- a/client/src/telethon/_impl/client/parsers/html.py
+++ b/client/src/telethon/_impl/client/parsers/html.py
@@ -48,7 +48,7 @@ class HTMLToTelegramParser(HTMLParser):
             EntityType = MessageEntityStrike
         elif tag == "blockquote":
             EntityType = MessageEntityBlockquote
-        elif tag == "details":
+        elif tag == "spoiler":
             EntityType = MessageEntitySpoiler
         elif tag == "code":
             try:
@@ -142,7 +142,7 @@ ENTITY_TO_FORMATTER: dict[
     MessageEntityUnderline: ("<u>", "</u>"),
     MessageEntityStrike: ("<del>", "</del>"),
     MessageEntityBlockquote: ("<blockquote>", "</blockquote>"),
-    MessageEntitySpoiler: ("<details>", "</details>"),
+    MessageEntitySpoiler: ("<spoiler>", "</spoiler>"),
     MessageEntityPre: lambda e, _: (
         '<pre><code class="language-{}">'.format(e.language) if e.language else "<pre>",
         "</code></pre>" if e.language else "</pre>",

--- a/client/src/telethon/_impl/client/parsers/html.py
+++ b/client/src/telethon/_impl/client/parsers/html.py
@@ -48,7 +48,7 @@ class HTMLToTelegramParser(HTMLParser):
             EntityType = MessageEntityStrike
         elif tag == "blockquote":
             EntityType = MessageEntityBlockquote
-        elif tag == "spoiler" or tag == "tg-spoiler":
+        elif tag == "details" or tag == "tg-spoiler":
             EntityType = MessageEntitySpoiler
         elif tag == "code":
             try:
@@ -142,7 +142,7 @@ ENTITY_TO_FORMATTER: dict[
     MessageEntityUnderline: ("<u>", "</u>"),
     MessageEntityStrike: ("<del>", "</del>"),
     MessageEntityBlockquote: ("<blockquote>", "</blockquote>"),
-    MessageEntitySpoiler: ("<spoiler>", "</spoiler>"),
+    MessageEntitySpoiler: ("<details>", "</details>"),
     MessageEntityPre: lambda e, _: (
         '<pre><code class="language-{}">'.format(e.language) if e.language else "<pre>",
         "</code></pre>" if e.language else "</pre>",

--- a/client/src/telethon/_impl/client/parsers/html.py
+++ b/client/src/telethon/_impl/client/parsers/html.py
@@ -48,7 +48,7 @@ class HTMLToTelegramParser(HTMLParser):
             EntityType = MessageEntityStrike
         elif tag == "blockquote":
             EntityType = MessageEntityBlockquote
-        elif tag == "spoiler":
+        elif tag == "spoiler" or tag == "tg-spoiler":
             EntityType = MessageEntitySpoiler
         elif tag == "code":
             try:

--- a/client/src/telethon/_impl/client/parsers/markdown.py
+++ b/client/src/telethon/_impl/client/parsers/markdown.py
@@ -43,6 +43,7 @@ HTML_TO_TYPE = {
     "del": ("s_close", "s_open"),
     "u": ("heading_open", "heading_close"),
     "mark": ("heading_open", "heading_close"),
+    "details": ("details_close", "details_open")
 }
 
 
@@ -138,6 +139,8 @@ def parse(message: str) -> tuple[str, list[MessageEntity]]:
                 push(MessageEntityTextUrl, url=token.attrs.get("href"))
         elif token.type in ("s_close", "s_open"):
             push(MessageEntityStrike)
+        elif token.type in ("details_close", "details_open"):
+            push(MessageEntitySpoiler)
         elif token.type == "softbreak":
             message += "\n"
         elif token.type in ("strong_close", "strong_open"):

--- a/client/src/telethon/_impl/client/parsers/markdown.py
+++ b/client/src/telethon/_impl/client/parsers/markdown.py
@@ -16,6 +16,7 @@ from ...tl.types import (
     MessageEntityStrike,
     MessageEntityTextUrl,
     MessageEntityUnderline,
+    MessageEntitySpoiler
 )
 from .strings import add_surrogate, del_surrogate, within_surrogate
 
@@ -27,6 +28,7 @@ DELIMITERS: dict[Type[MessageEntity], tuple[str, str]] = {
     MessageEntityItalic: ("_", "_"),
     MessageEntityStrike: ("~~", "~~"),
     MessageEntityUnderline: ("# ", ""),
+    MessageEntitySpoiler: ("||", "||")
 }
 
 # Not trying to be complete; just enough to have an alternative (mostly for inline underline).


### PR DESCRIPTION
- 1- Rename `details` tag to `spoiler` in **html** parser.
- 2- Add `"||" ` syntax for markdown parser, so now we can send spoiler text totally like [Telegram Bot API](https://core.telegram.org/bots/api#markdownv2-style).