### PR TITLE
Include Underline in markdown

### DIFF
--- a/telethon/extensions/markdown.py
+++ b/telethon/extensions/markdown.py
@@ -11,12 +11,13 @@ from ..tl import TLObject
 from ..tl.types import (
     MessageEntityBold, MessageEntityItalic, MessageEntityCode,
     MessageEntityPre, MessageEntityTextUrl, MessageEntityMentionName,
-    MessageEntityStrike
+    MessageEntityStrike, MessageEntityUnderline
 )
 
 DEFAULT_DELIMITERS = {
     '**': MessageEntityBold,
     '__': MessageEntityItalic,
+    '++': MessageEntityUnderline,
     '~~': MessageEntityStrike,
     '`': MessageEntityCode,
     '```': MessageEntityPre


### PR DESCRIPTION
and i know your not really accepting PRs but
Im not sure why this is not actually here?
It is with the html parser, but as you know you cant parse html white using CustomMarkdown

<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->
