### PR TITLE
Fix self_user setting in chat_hashes

### DIFF
--- a/client/src/telethon/_impl/client/client/net.py
+++ b/client/src/telethon/_impl/client/client/net.py
@@ -193,10 +193,9 @@ async def connect(self: Client) -> None:
             me = await self.get_me()
             assert me is not None
             self._chat_hashes.set_self_user(me.id, me.bot)
-            if not self._session.user:
-                self._session.user = SessionUser(
-                    id=me.id, dc=self._sender.dc_id, bot=me.bot, username=me.username
-                )
+            self._session.user = SessionUser(
+                id=me.id, dc=self._sender.dc_id, bot=me.bot, username=me.username
+            )
 
     self._dispatcher = asyncio.create_task(dispatcher(self))
 

--- a/client/src/telethon/_impl/client/client/net.py
+++ b/client/src/telethon/_impl/client/client/net.py
@@ -190,13 +190,13 @@ async def connect(self: Client) -> None:
         except Exception:
             pass
         else:
+            me = await self.get_me()
+            assert me is not None
+            self._chat_hashes.set_self_user(me.id, me.bot)
             if not self._session.user:
-                me = await self.get_me()
-                assert me is not None
                 self._session.user = SessionUser(
                     id=me.id, dc=self._sender.dc_id, bot=me.bot, username=me.username
                 )
-                self._chat_hashes.set_self_user(me.id, me.bot)
 
     self._dispatcher = asyncio.create_task(dispatcher(self))
 


### PR DESCRIPTION
There was an issue when `chat_hashes._self_id` wasn't initialized after the client connection, causing an `AssertionError` when getting updates.

```
File "telethon/_impl/client/client/net.py", line 289, in step_sender
  process_socket_updates(client, updates)
File "telethon/_impl/client/client/updates.py", line 88, in process_socket_updates
  result, users, chats = client._message_box.process_updates(
File "telethon/_impl/session/message_box/messagebox.py", line 264, in process_updates
  combined = adapt(updates, chat_hashes)
File "telethon/_impl/session/message_box/adaptor.py", line 152, in adapt
  return update_short_message(updates, chat_hashes.self_id)
File "telethon/_impl/session/chat/hash_cache.py", line 19, in self_id
  assert self._self_id is not None
```

I haven't found any other place where `self._chat_hashes.self_user` assigns values, so the solution might be something like this.

Also, I'm not sure about the logical correctness of the original code:

```python
if ... self._session.user:
    try:
        ...
    except RpcError as e:
        ...
        self._session.user = None
    else:
        if not self._session.user:
            ...
```

How can the `if not self._session.user` condition be fulfilled after the contradictory parent condition, assuming that the `else` part can't be executed after the exception above?