### PR TITLE
[V2] Fix multiple annotation of abstract class

### DIFF
--- a/client/src/telethon/_impl/client/client/bots.py
+++ b/client/src/telethon/_impl/client/client/bots.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Optional, Self
 
 from ...session import PeerRef, UserRef
-from ...tl import functions, types
+from ...tl import abcs, functions, types
 from ..types import InlineResult, NoPublicConstructor, Peer, User
 
 if TYPE_CHECKING:
@@ -15,7 +15,7 @@ class InlineResults(metaclass=NoPublicConstructor):
     def __init__(
         self,
         client: Client,
-        bot: types.InputUser,
+        bot: abcs.InputUser,
         query: str,
         peer: Optional[PeerRef],
     ):

--- a/client/src/telethon/_impl/client/client/users.py
+++ b/client/src/telethon/_impl/client/client/users.py
@@ -66,9 +66,9 @@ async def resolve_username(self: Client, username: str, /) -> Peer:
 
 async def resolve_peers(self: Client, peers: Sequence[Peer | PeerRef], /) -> list[Peer]:
     refs: list[PeerRef] = []
-    input_users: list[types.InputUser] = []
+    input_users: list[abcs.InputUser] = []
     input_chats: list[int] = []
-    input_channels: list[types.InputChannel] = []
+    input_channels: list[abcs.InputChannel] = []
 
     for peer in peers:
         peer = peer._ref

--- a/client/src/telethon/_impl/client/events/filters/combinators.py
+++ b/client/src/telethon/_impl/client/events/filters/combinators.py
@@ -35,7 +35,7 @@ class Combinable(abc.ABC):
         return self.filter if isinstance(self, Not) else Not(self)
 
     @abc.abstractmethod
-    async def __call__(self, event: Event) -> bool:
+    def __call__(self, event: Event) -> bool | Awaitable[bool]:
         pass
 
 

--- a/client/src/telethon/_impl/client/types/keyboard.py
+++ b/client/src/telethon/_impl/client/types/keyboard.py
@@ -1,14 +1,14 @@
-from typing import Optional, TypeAlias
+from typing import Optional, TypeAlias, TypeVar
 
 from ...tl import abcs, types
 from .buttons import Button, InlineButton
 
+AnyButton = TypeVar("AnyButton", bound=Button)
+AnyInlineButton = TypeVar("AnyInlineButton", bound=InlineButton)
+
 
 def _build_keyboard_rows(
-    btns: list[Button]
-    | list[list[Button]]
-    | list[InlineButton]
-    | list[list[InlineButton]],
+    btns: list[AnyButton] | list[list[AnyButton]],
 ) -> list[abcs.KeyboardButtonRow]:
     # list[button] -> list[list[button]]
     # This does allow for "invalid" inputs (mixing lists and non-lists), but that's acceptable.
@@ -29,7 +29,7 @@ class Keyboard:
 
     def __init__(
         self,
-        buttons: list[Button] | list[list[Button]],
+        buttons: list[AnyButton] | list[list[AnyButton]],
         resize: bool,
         single_use: bool,
         selective: bool,
@@ -49,7 +49,9 @@ class Keyboard:
 class InlineKeyboard:
     __slots__ = ("_raw",)
 
-    def __init__(self, buttons: list[InlineButton] | list[list[InlineButton]]) -> None:
+    def __init__(
+        self, buttons: list[AnyInlineButton] | list[list[AnyInlineButton]]
+    ) -> None:
         self._raw = types.ReplyInlineMarkup(rows=_build_keyboard_rows(buttons))
 
 

--- a/client/src/telethon/_impl/tl/core/reader.py
+++ b/client/src/telethon/_impl/tl/core/reader.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
         def __buffer__(self, flags: int, /) -> memoryview: ...
 
 
-SerializableType = TypeVar("SerializableType", bound="Serializable")
+AnySerializable = TypeVar("AnySerializable", bound="Serializable")
 
 
 def _bootstrap_get_ty(constructor_id: int) -> Optional[Type["Serializable"]]:
@@ -79,7 +79,7 @@ class Reader:
 
     _get_ty = staticmethod(_bootstrap_get_ty)
 
-    def read_serializable(self, cls: Type[SerializableType]) -> SerializableType:
+    def read_serializable(self, cls: Type[AnySerializable]) -> AnySerializable:
         # Calls to this method likely need to ignore "type-abstract".
         # See https://github.com/python/mypy/issues/4717.
         # Unfortunately `typing.cast` would add a tiny amount of runtime overhead
@@ -95,9 +95,9 @@ class Reader:
 
 @functools.cache
 def single_deserializer(
-    cls: Type[SerializableType],
-) -> Callable[[bytes], SerializableType]:
-    def deserializer(body: bytes) -> SerializableType:
+    cls: Type[AnySerializable],
+) -> Callable[[bytes], AnySerializable]:
+    def deserializer(body: bytes) -> AnySerializable:
         return Reader(body).read_serializable(cls)
 
     return deserializer
@@ -105,9 +105,9 @@ def single_deserializer(
 
 @functools.cache
 def list_deserializer(
-    cls: Type[SerializableType],
-) -> Callable[[bytes], list[SerializableType]]:
-    def deserializer(body: bytes) -> list[SerializableType]:
+    cls: Type[AnySerializable],
+) -> Callable[[bytes], list[AnySerializable]]:
+    def deserializer(body: bytes) -> list[AnySerializable]:
         reader = Reader(body)
         vec_id, length = reader.read_fmt("<ii", 8)
         assert vec_id == 0x1CB5C415 and length >= 0


### PR DESCRIPTION
<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->

Annotating abstract class works, however, `list[AbcClass] | list[AbcClass]` annotation causes an incompatible error in mypy
