### PR TITLE
Fix get_messages when `reverse=True` (#4453)

### DIFF
--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -221,7 +221,7 @@ class _MessagesIter(RequestIter):
         #
         # We also assume the API will always return, at least, one message if
         # there is more to fetch.
-        if not r.messages or not self.reverse and r.messages[0].id <= self.request.limit:
+        if not r.messages or (not self.reverse and r.messages[0].id <= self.request.limit):
             return True
 
         # Get the last message that's not empty (in some rare cases

--- a/telethon/client/messages.py
+++ b/telethon/client/messages.py
@@ -221,7 +221,7 @@ class _MessagesIter(RequestIter):
         #
         # We also assume the API will always return, at least, one message if
         # there is more to fetch.
-        if not r.messages or r.messages[0].id <= self.request.limit:
+        if not r.messages or not self.reverse and r.messages[0].id <= self.request.limit:
             return True
 
         # Get the last message that's not empty (in some rare cases


### PR DESCRIPTION
Close #4453 

https://github.com/LonamiWebs/Telethon/blob/aec957d62da03d511b7a656a76490e882f740024/telethon/client/messages.py#L224

I assume that the original goal of this condition was to reduce the number of requests to the Telegram API. To understand when the condition should trigger, let's conduct an experiment:

### `reverse=False`

* All messages have sequential IDs from 1 to the total number of messages, let’s say 500:

> Received IDs will look like [500...401] [400...301] [300...201] [200...101] [100...1]  
> `r.messages[0].id = 100`  
> `100 <= 100 -> True`

* Some messages in the sequence are deleted, so they have non-sequential IDs:

> Received IDs will look like [517...416] [415...314] [313...208] [207...103] [102...1]  
> `r.messages[0].id = 102`  
> `102 <= 100 -> False`

* All messages have sequential IDs from 1, and the total number of messages is 154:

> Received IDs will look like [154...55] [54...1]  
> `r.messages[0].id = 54`  
> `54 <= 100 -> True`

* Some messages in the sequence are deleted, so they have non-sequential IDs:

> Received IDs will look like [156...57] [56...1]  
> `r.messages[0].id = 56`  
> `56 <= 100 -> True`

### `reverse=True`

* All messages have sequential IDs from 1, and the total number of messages is 500:

> Received IDs will look like [100...1]  
> `r.messages[0].id = 100`  
> `100 <= 100 -> True` ERROR!

* Some messages in the sequence are deleted, so they have non-sequential IDs:

> Received IDs will look like [102...1] [207...103] [313...208] [415...314] [517...416]  
> `r.messages[0].id = 517`  
> `517 <= 100 -> False`

* All messages have sequential IDs from 1, and the total number of messages is 154:

> Received IDs will look like [100...1]
> `r.messages[0].id = 100`  
> `100 <= 100 -> True` ERROR!

* Some messages in the sequence are deleted, so they have non-sequential IDs:

> Received IDs will look like [102...1] [156...103]  
> `r.messages[0].id = 156`  
> `156 <= 100 -> False`

As we can see, the error only occurs when `reverse=True`.
