### PR TITLE
Fixed typo in logging messages

### DIFF
--- a/readthedocs/basic/updates.rst
+++ b/readthedocs/basic/updates.rst
@@ -16,7 +16,7 @@ For that, you can use **events**.
     .. code-block:: python
 
         import logging
-        logging.basicConfig(format='[%(levelname) 5s/%(asctime)s] %(name)s: %(message)s',
+        logging.basicConfig(format='[%(levelname) %(asctime)s] %(name)s: %(message)s',
                             level=logging.WARNING)
 
 


### PR DESCRIPTION
Redundant "5s/" text is removed from log messages