### PR TITLE
fix(session): persist session after `session.set_dc`

### DIFF
--- a/telethon/client/telegrambaseclient.py
+++ b/telethon/client/telegrambaseclient.py
@@ -313,6 +313,7 @@ class TelegramBaseClient(abc.ABC):
                 DEFAULT_IPV6_IP if self._use_ipv6 else DEFAULT_IPV4_IP,
                 DEFAULT_PORT
             )
+            session.save()
 
         self.flood_sleep_threshold = flood_sleep_threshold
 


### PR DESCRIPTION
Hey here!

**Current behavior:**
If you create a `TelegramClient` and do NOT `connect` or `start` it (just initialize `TelegramClient`), and the session does not exist, it auto-creates the `.session` and `.session-journal`, the SQLite stays locked, since the transaction is not finished.

Is there any specific reason it's like this, or is this a bug?

**PR behavior:**
Persist the changes, so there's no lock in SQLite.

**NOTE:**
IMHO it would be helpful when the user needs to create a client and work with it later.
Also, it doesn't leave unused `.session-journal` after the python process closes.
