### PR TITLE
Unconditionally match text and link text in markdown

### DIFF
--- a/telethon/extensions/markdown.py
+++ b/telethon/extensions/markdown.py
@@ -22,7 +22,7 @@ DEFAULT_DELIMITERS = {
     '```': MessageEntityPre
 }
 
-DEFAULT_URL_RE = re.compile(r'\[([^\]]+)\]\(([^)]+)\)')
+DEFAULT_URL_RE = re.compile(r'\[([\s\S]+)\]\((.+)\)')
 DEFAULT_URL_FORMAT = '[{0}]({1})'
 
 


### PR DESCRIPTION
Fixes cases where there's a nested [] in the text by matching until "](" is reached. This doesn't match newlines in URLs because that makes no sense.