### PR TITLE
Fix overlapping URLs and improve overlapping in md

### DIFF
--- a/telethon/extensions/markdown.py
+++ b/telethon/extensions/markdown.py
@@ -26,10 +26,6 @@ DEFAULT_URL_RE = re.compile(r'\[([\s\S]+)\]\((.+)\)')
 DEFAULT_URL_FORMAT = '[{0}]({1})'
 
 
-def overlap(a, b, x, y):
-    return max(a, x) < min(b, y)
-
-
 def parse(message, delimiters=None, url_re=None):
     """
     Parses the given markdown message and returns its stripped representation
@@ -90,8 +86,8 @@ def parse(message, delimiters=None, url_re=None):
                 for ent in result:
                     # If the end is after our start, it is affected
                     if ent.offset + ent.length > i:
-                        # If the old start is also before ours, it is fully enclosed
-                        if ent.offset <= i:
+                        # If the old start is before ours and the old end is after ours, we are fully enclosed
+                        if ent.offset <= i and ent.offset + ent.length >= end + len(delim):
                             ent.length -= len(delim) * 2
                         else:
                             ent.length -= len(delim)
@@ -119,7 +115,7 @@ def parse(message, delimiters=None, url_re=None):
                     message[m.end():]
                 ))
 
-                delim_size = m.end() - m.start() - len(m.group())
+                delim_size = m.end() - m.start() - len(m.group(1))
                 for ent in result:
                     # If the end is after our start, it is affected
                     if ent.offset + ent.length > m.start():


### PR DESCRIPTION
Also remove the unused overlap function. May need testing but works for me.

I tested it with this: `"**__[foo](https://example.com)**\n**h__elp __why** a**m I** b**__aldi**ng\n**__egg__2**"`