### PR TITLE
fix: support batch sending of image URLs and video URLs in albums

### DIFF
--- a/telethon/client/uploads.py
+++ b/telethon/client/uploads.py
@@ -516,7 +516,7 @@ class UploadMethods:
                 ))
 
                 fm = utils.get_input_media(r.photo)
-            elif isinstance(fm, types.InputMediaUploadedDocument):
+            elif isinstance(fm, (types.InputMediaUploadedDocument, types.InputMediaDocumentExternal)):
                 r = await self(functions.messages.UploadMediaRequest(
                     entity, media=fm
                 ))


### PR DESCRIPTION
Currently, using 
```
album = [
    InputMediaPhotoExternal("https://example.com/a.png"),
    InputMediaDocumentExternal("https://example.com/b.mp4")
]
await client.send_file(chat, album, caption="It's me!")
```
 in the branch results in an error: "Media invalid (caused by SendMultiMediaRequest)".

This PR fixes this issue. I have tested it and it is working correctly.