### PR TITLE
Consider range list-like

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -899,7 +899,7 @@ def is_list_like(obj):
     enough. Things like ``open()`` are also iterable (and probably many
     other things), so just support the commonly known list-like objects.
     """
-    return isinstance(obj, (list, tuple, set, dict, GeneratorType))
+    return isinstance(obj, (list, tuple, set, dict, range, GeneratorType))
 
 
 def parse_phone(phone):


### PR DESCRIPTION
This allows you to pass range() to things such as get_messages as ids= without first explicitly converting it to a list.

Range supports iteration, indexing, and slicing, so this works fine.