### PR TITLE
Prefer session qts if session qts is higher than getState qts

### DIFF
--- a/telethon/client/auth.py
+++ b/telethon/client/auth.py
@@ -392,6 +392,17 @@ class AuthMethods:
         self._authorized = True
 
         state = await self(functions.updates.GetStateRequest())
+        session_state = self.session.get_update_state(0)
+
+        if session_state and session_state.qts > state.qts:
+            if __debug__:
+                self._message_box._trace(
+                    'Local session qts higher than getState qts, using local, local qts = %r, getState qts = %r',
+                    session_state.qts, state.qts
+                )
+
+            state.qts = session_state.qts
+
         self._message_box.load(SessionState(0, 0, 0, state.pts, state.qts, int(state.date.timestamp()), state.seq, 0), [])
 
         return user


### PR DESCRIPTION
Telegram may send a lower qts than the last qts we got from events in getState, for some reason. Fixes event replay in things like business messages as a bot account.