### PR TITLE
Fix of some bugs.

### DIFF
--- a/telethon/_updates/session.py
+++ b/telethon/_updates/session.py
@@ -1,7 +1,7 @@
 from typing import Optional, Tuple
 from enum import IntEnum
 from ..tl.types import InputPeerUser, InputPeerChat, InputPeerChannel
-
+import struct
 
 class SessionState:
     """
@@ -173,7 +173,7 @@ class Entity:
         try:
             ty, id, hash = struct.unpack('<Bqq', blob)
         except struct.error:
-            raise ValueError(f'malformed entity data, got {string!r}') from None
+            raise ValueError(f'malformed entity data, got {blob!r}') from None
 
         return cls(EntityType(ty), id, hash)
 

--- a/telethon/client/downloads.py
+++ b/telethon/client/downloads.py
@@ -992,8 +992,8 @@ class DownloadMethods:
             )
 
         # TODO Better way to get opened handles of files and auto-close
-        kind, possible_names = self._get_kind_and_names(web.attributes)
-        file = self._get_proper_filename(
+        kind, possible_names = cls._get_kind_and_names(web.attributes)
+        file = cls._get_proper_filename(
             file, kind, utils.get_extension(web),
             possible_names=possible_names
         )

--- a/telethon/tl/custom/button.py
+++ b/telethon/tl/custom/button.py
@@ -49,6 +49,7 @@ class Button:
         Returns `True` if the button belongs to an inline keyboard.
         """
         return isinstance(button, (
+            types.KeyboardButtonCopy,
             types.KeyboardButtonBuy,
             types.KeyboardButtonCallback,
             types.KeyboardButtonGame,


### PR DESCRIPTION
Added KeyboardButtonCopy instance since it's a inline button and it makes build_reply_markup static method of TelegramClient work correctly. ( tl/Custom/button.py )

Fixed some bugs in _updates/session.py and client/downloads.py

I wish it helps you.
<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->
