### PR TITLE
open_url argument added to prevent browser from opening

### DIFF
--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -871,7 +871,7 @@ class Message(ChatGetter, SenderGetter, TLObject):
 
     async def click(self, i=None, j=None,
                     *, text=None, filter=None, data=None, share_phone=None,
-                    share_geo=None, password=None):
+                    share_geo=None, password=None, open_url=None):
         """
         Calls :tl:`SendVote` with the specified poll option
         or `button.click <telethon.tl.custom.messagebutton.MessageButton.click>`
@@ -985,7 +985,7 @@ class Message(ChatGetter, SenderGetter, TLObject):
 
             but = types.KeyboardButtonCallback('', data)
             return await MessageButton(self._client, but, chat, None, self.id).click(
-                share_phone=share_phone, share_geo=share_geo, password=password)
+                share_phone=share_phone, share_geo=share_geo, password=password, open_url=open_url)
 
         if sum(int(x is not None) for x in (i, text, filter)) >= 2:
             raise ValueError('You can only set either of i, text or filter')
@@ -1058,7 +1058,7 @@ class Message(ChatGetter, SenderGetter, TLObject):
         button = find_button()
         if button:
             return await button.click(
-                share_phone=share_phone, share_geo=share_geo, password=password)
+                share_phone=share_phone, share_geo=share_geo, password=password, open_url=open_url)
 
     async def mark_read(self):
         """

--- a/telethon/tl/custom/message.py
+++ b/telethon/tl/custom/message.py
@@ -955,7 +955,13 @@ class Message(ChatGetter, SenderGetter, TLObject):
                 button to transfer ownership), if your account has 2FA enabled,
                 you need to provide your account's password. Otherwise,
                 `teltehon.errors.PasswordHashInvalidError` is raised.
-
+            
+            open_url (`bool`):
+                When clicking on an inline keyboard URL button :tl:`KeyboardButtonUrl`
+                By default it will return URL of the button, passing ``click(open_url=True)``
+                will lunch the default browser with given URL of the button and 
+                return `True` on success.
+                
             Example:
 
                 .. code-block:: python

--- a/telethon/tl/custom/messagebutton.py
+++ b/telethon/tl/custom/messagebutton.py
@@ -65,7 +65,7 @@ class MessageButton:
         if isinstance(self.button, types.KeyboardButtonUrl):
             return self.button.url
 
-    async def click(self, share_phone=None, share_geo=None, *, password=None):
+    async def click(self, share_phone=None, share_geo=None, *, password=None, open_url=None):
         """
         Emulates the behaviour of clicking this button.
 
@@ -79,7 +79,8 @@ class MessageButton:
         :tl:`StartBotRequest` will be invoked and the resulting updates
         returned.
 
-        If it's a :tl:`KeyboardButtonUrl`, the URL of the button will
+        If it's a :tl:`KeyboardButtonUrl`, the ``URL`` of the button will
+        be returned. If you pass ``open_url=True`` the URL of the button will
         be passed to ``webbrowser.open`` and return `True` on success.
 
         If it's a :tl:`KeyboardButtonRequestPhone`, you must indicate that you
@@ -116,8 +117,10 @@ class MessageButton:
                 bot=self._bot, peer=self._chat, start_param=self.button.query
             ))
         elif isinstance(self.button, types.KeyboardButtonUrl):
-            if "webbrowser" in sys.modules:
-                return webbrowser.open(self.button.url)
+            if open_url:
+                if "webbrowser" in sys.modules:
+                    return webbrowser.open(self.button.url)
+            return self.button.url
         elif isinstance(self.button, types.KeyboardButtonGame):
             req = functions.messages.GetBotCallbackAnswerRequest(
                 peer=self._chat, msg_id=self._msg_id, game=True


### PR DESCRIPTION
continuation of the first pull request: passing open_url=True will open browser and return True on success  else it will just return the button's URL to be processed via code.