### PR TITLE
Add ChannelForbidden check to utils.get_display_name

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -95,7 +95,8 @@ def get_display_name(entity):
         else:
             return ''
 
-    elif isinstance(entity, (types.Chat, types.ChatForbidden, types.Channel)):
+    elif isinstance(entity, (
+            types.Chat, types.ChatForbidden, types.Channel, types.ChannelForbidden)):
         return entity.title
 
     return ''


### PR DESCRIPTION
`ChannelForbidden` has `title` as well, so it makes sense to check it as well.

This is just a small qol improvement