### PR TITLE
Fix spoilers when sending InputPhoto and InputDocument

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -437,9 +437,9 @@ def get_input_media(
         if media.SUBCLASS_OF_ID == 0xfaf846f4:  # crc32(b'InputMedia')
             return media
         elif media.SUBCLASS_OF_ID == 0x846363e0:  # crc32(b'InputPhoto')
-            return types.InputMediaPhoto(media, ttl_seconds=ttl)
+            return types.InputMediaPhoto(media, ttl_seconds=ttl, spoiler=media.spoiler)
         elif media.SUBCLASS_OF_ID == 0xf33fdb68:  # crc32(b'InputDocument')
-            return types.InputMediaDocument(media, ttl_seconds=ttl)
+            return types.InputMediaDocument(media, ttl_seconds=ttl, spoiler=media.spoiler)
     except AttributeError:
         _raise_cast_fail(media, 'InputMedia')
 


### PR DESCRIPTION
After this was reported as a problem for MessageMediaPhoto objects in #4584, it was fixed in commit 37e29e8, but the problem exists for InputPhoto and InputDocument, also. This commit fixes that

<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->
