### PR TITLE
Stop using the event_loop fixture

### DIFF
--- a/tests/telethon/test_helpers.py
+++ b/tests/telethon/test_helpers.py
@@ -39,9 +39,9 @@ def test_strip_text():
 
 class TestSyncifyAsyncContext:
     class NoopContextManager:
-        def __init__(self, loop):
+        def __init__(self):
             self.count = 0
-            self.loop = loop
+            self.loop = helpers.get_running_loop()
 
         async def __aenter__(self):
             self.count += 1
@@ -54,8 +54,8 @@ class TestSyncifyAsyncContext:
         __enter__ = helpers._sync_enter
         __exit__ = helpers._sync_exit
 
-    def test_sync_acontext(self, event_loop):
-        contm = self.NoopContextManager(event_loop)
+    def test_sync_acontext(self):
+        contm = self.NoopContextManager()
         assert contm.count == 0
 
         with contm:
@@ -64,8 +64,8 @@ class TestSyncifyAsyncContext:
         assert contm.count == 0
 
     @pytest.mark.asyncio
-    async def test_async_acontext(self, event_loop):
-        contm = self.NoopContextManager(event_loop)
+    async def test_async_acontext(self):
+        contm = self.NoopContextManager()
         assert contm.count == 0
 
         async with contm:


### PR DESCRIPTION
pytest-asyncio has deprecated (and in 1.0, removed) the event_loop fixture, which is only used for one testcase. Use the get_running_loop() helper function instead.

<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->
