### PR TITLE
Revert "Fix spoilers when sending InputPhoto and InputDocument"

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -438,9 +438,9 @@ def get_input_media(
         if media.SUBCLASS_OF_ID == 0xfaf846f4:  # crc32(b'InputMedia')
             return media
         elif media.SUBCLASS_OF_ID == 0x846363e0:  # crc32(b'InputPhoto')
-            return types.InputMediaPhoto(media, ttl_seconds=ttl, spoiler=media.spoiler)
+            return types.InputMediaPhoto(media, ttl_seconds=ttl)
         elif media.SUBCLASS_OF_ID == 0xf33fdb68:  # crc32(b'InputDocument')
-            return types.InputMediaDocument(media, ttl_seconds=ttl, spoiler=media.spoiler)
+            return types.InputMediaDocument(media, ttl_seconds=ttl)
     except AttributeError:
         _raise_cast_fail(media, 'InputMedia')
 


### PR DESCRIPTION
Reverts LonamiWebs/Telethon#4666

When passing a raw `types.InputDocument` or `types.InputPhoto` object to `client.send_file`, the operation **silently fails** (the file is not sent). No obvious errors arise.
The code in `telethon/utils.py::get_input_media` attempts to access the `spoiler` attribute on these objects, but `types.InputPhoto` and `types.InputDocument` (as per TL schema) **do not have a `spoiler` attribute**. This leads to an internal failure that prevents the media from being processed and sent.