### PR TITLE
Ensure document spoiler is preserved in utils.get_input_media

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -460,6 +460,7 @@ def get_input_media(
     if isinstance(media, types.MessageMediaDocument):
         return types.InputMediaDocument(
             id=get_input_document(media.document),
+            spoiler=media.spoiler,
             ttl_seconds=ttl or media.ttl_seconds
         )
 

--- a/telethon/version.py
+++ b/telethon/version.py
@@ -1,3 +1,3 @@
 # Versions should comply with PEP440.
 # This line is parsed in setup.py:
-__version__ = '1.41.1'
+__version__ = '1.41.2'


### PR DESCRIPTION
For consistency with MessageMediaPhoto spoiler preservation. 