### PR TITLE
Correct handling of trailing zeros in _rle_encode

### DIFF
--- a/telethon/utils.py
+++ b/telethon/utils.py
@@ -1095,6 +1095,8 @@ def _rle_encode(string):
                 count = 0
 
             new += bytes([cur])
+    if count != 0:
+        new += b'\0' + bytes([count])
     return new
 
 

--- a/tests/telethon/test_utils.py
+++ b/tests/telethon/test_utils.py
@@ -52,3 +52,7 @@ def test_private_get_extension():
     assert utils._get_extension(empty_buffer) == ''
     assert utils._get_extension(empty_buffer) == ''  # make sure it did seek back
     assert utils._get_extension(CustomFd('foo')) == ''
+
+
+def test_rle_encode_trailing_zeros():
+    assert utils._rle_encode(b'\x12\x00\x00\x00\x00') == b'\x12\x00\x04'


### PR DESCRIPTION
<!--
Thanks for the PR! Please keep in mind that v1 is *feature frozen*.
New features very likely won't be merged, although fixes can be sent.
All new development should happen in v2. Thanks!
-->

Fix for the missing RLE encoding if zeros are in the end of the byte array